### PR TITLE
implement getnodecount, don't throw error for 0 nodes

### DIFF
--- a/src/CplexSolverInterface.jl
+++ b/src/CplexSolverInterface.jl
@@ -169,6 +169,7 @@ getconstrsolution(m::CplexMathProgModel) = get_constr_solution(m.inner)
 getreducedcosts(m::CplexMathProgModel) = get_reduced_costs(m.inner)
 getconstrduals(m::CplexMathProgModel) = get_constr_duals(m.inner)
 getrawsolver(m::CplexMathProgModel) = m.inner
+getnodecount(m::CplexMathProgModel) = get_node_count(m.inner)
 
 const var_type_map = Compat.@compat Dict(
   'C' => :Cont,
@@ -225,7 +226,6 @@ setquadobj!(m::CplexMathProgModel,rowidx,colidx,quadval) = add_qpterms!(m.inner,
 ######
 # Data
 ######
-getnodecnt(m::CplexMathProgModel) = @cpx_ccall(getnodecnt, Cint, (Ptr{Void},Ptr{Void}), m.inner.env.ptr, m.inner.lp)
 function getdettime(m::CplexMathProgModel)
     tim = Array(Cdouble,1)
     stat = @cpx_ccall(getdettime, Cint, (Ptr{Void},Ptr{Cdouble}), m.inner.env.ptr, tim)

--- a/src/cpx_solve.jl
+++ b/src/cpx_solve.jl
@@ -193,11 +193,7 @@ function get_basis(model::Model)
     return cbasis, rbasis
 end
 
-function get_node_count(model::Model)
-  ret = @cpx_ccall(getnodecnt, Cint, (Ptr{Void},Ptr{Void}), model.env.ptr, model.lp)
-  ret == 0 && error("Error getting node count")
-  return ret
-end
+get_node_count(model::Model) = @cpx_ccall(getnodecnt, Cint, (Ptr{Void},Ptr{Void}), model.env.ptr, model.lp)
 
 function get_num_cuts(model::Model,cuttype)
     cutcount = Array(Cint,1)


### PR DESCRIPTION
Implements `MathProgBase.getnodecount` and deletes duplicate function `getnodecnt`.
Also, `get_node_count` shouldn't throw an error if node count is 0.

See JuliaOpt/JuMP.jl#442