### PR TITLE
Check problem type after reading from file

### DIFF
--- a/src/CplexSolverInterface.jl
+++ b/src/CplexSolverInterface.jl
@@ -29,7 +29,16 @@ end
 CplexSolver(;kwargs...) = CplexSolver(kwargs)
 model(s::CplexSolver) = CplexMathProgModel(;s.options...)
 
-loadproblem!(m::CplexMathProgModel, filename::String) = read_model(m.inner, filename)
+function loadproblem!(m::CplexMathProgModel, filename::String)
+   read_model(m.inner, filename)
+   prob_type = get_prob_type(m.inner)
+   if prob_type in [:MILP,:MIQP, :MIQCP]
+      m.inner.has_int = true
+   end
+   if prob_type in [:QP, :MIQP, :QCP, :MIQCP]
+      m.inner.has_qc = true
+   end
+end
 
 function loadproblem!(m::CplexMathProgModel, A, collb, colub, obj, rowlb, rowub, sense)
   add_vars!(m.inner, float(obj), float(collb), float(colub))


### PR DESCRIPTION
Need to set `has_int` and `has_qc` when appropriate.

Somewhat related: not sure if `has_qc` should be true if only the objective is quadratic (QP, MIQP).
Both `CPXlpopt()` and `CPXqpopt()` accept the model, but I haven't checked if they actually do the same thing or maybe use a different method (possibly different defaults). 