### PR TITLE
int(x) warnings suppressed

### DIFF
--- a/src/cpx_model.jl
+++ b/src/cpx_model.jl
@@ -122,7 +122,7 @@ function get_prob_type(model::Model)
                    Ptr{Void}),
                    model.env.ptr, model.lp)
   ret == -1 && error("No problem of environment")
-  return type_map[int(ret)]
+  return type_map[@compat Int(ret)]
 end
 
 function set_obj!(model::Model, c::Vector)

--- a/src/cpx_solve.jl
+++ b/src/cpx_solve.jl
@@ -254,5 +254,5 @@ const status_symbols = Compat.@compat Dict(
     121 => :CPXMIP_OPTIMAL_RELAXED
 )
 
-get_status(model::Model) = status_symbols[int(get_status_code(model))]::Symbol
+get_status(model::Model) = status_symbols[@compat Int(get_status_code(model))]::Symbol
 get_status_code(model::Model) = @cpx_ccall(getstat, Cint, (Ptr{Void}, Ptr{Void}), model.env.ptr, model.lp)


### PR DESCRIPTION
these lines generate deprecated warnings with julia 0.4