### PR TITLE
support for _local_ lazy constraints and user cuts (cplex)

### DIFF
--- a/src/CplexSolverInterface.jl
+++ b/src/CplexSolverInterface.jl
@@ -364,10 +364,23 @@ function cbaddcut!(d::CplexCallbackData,varidx,varcoef,sense,rhs)
     unsafe_store!(d.userinteraction_p, convert(Cint,CPX_CALLBACK_ABORT_CUT_LOOP), 1)
 end
 
+function cbaddcutlocal!(d::CplexCallbackData,varidx,varcoef,sense,rhs)
+    @assert d.state == :MIPNode
+    cbcutlocal(d.cbdata, d.where, convert(Vector{Cint}, varidx), float(varcoef), sensemap[sense], float(rhs))
+    unsafe_store!(d.userinteraction_p, convert(Cint,CPX_CALLBACK_ABORT_CUT_LOOP), 1)
+end
+
+
 function cbaddlazy!(d::CplexCallbackData,varidx,varcoef,sense,rhs)
     @assert d.state == :MIPNode || d.state == :MIPSol
     cblazy(d.cbdata, d.where, convert(Vector{Cint}, varidx), float(varcoef), sensemap[sense], float(rhs))
 end
+
+function cbaddlazylocal!(d::CplexCallbackData,varidx,varcoef,sense,rhs)
+    @assert d.state == :MIPNode || d.state == :MIPSol
+    cblazylocal(d.cbdata, d.where, convert(Vector{Cint}, varidx), float(varcoef), sensemap[sense], float(rhs))
+end
+
 
 function cbaddsolution!(d::CplexCallbackData)
     val = pointer_to_array(d.userinteraction_p, 1)


### PR DESCRIPTION
First, thanks a lot for all these wonderful and truely useful tools!

Having re-coded some algorithm using _local_ lazy constraints* with Julia/JuMP, here is a suggestion of very small additions handling them in JuMP/MathProgBase/CPLEX (joint additions, cf the forks at https://github.com/madanim). As far as I know, this feature is only avalaible in CPLEX and XPress MP.

It simply consists in duplicating the current mechanics for lazy constraints and user cuts, and using the CPLEX naming convention, appending 'local' or 'Local' where applicable: e.g. '@addLazyConstraintLocal' instead of '@addLazyConstraint', etc (in the CPLEX C Api the variant is 'cutcallbackaddlocal' instead of 'cutcallbackadd').

Do you think this way of proceeding is consistent with the packages design, or would it be preferable to handle the feature by passing a parameter value (as in AIMMS) throughout the 'call chain' instead - e.g. for maintenance purposes ? And displaying an error message when used with solvers not supporting the feature ?

Thanks a lot!,

Kind Regards,

Mehdi


*http://www.ibm.com/support/knowledgecenter/SS9UKU_12.6.0/com.ibm.cplex.zos.help/refcallablelibrary/mipapi/cutcallbackaddlocal.html