### PR TITLE
:UserLimit is now returned when cplex status contains TIME_LIM and not ABORT

### DIFF
--- a/src/CplexSolverInterface.jl
+++ b/src/CplexSolverInterface.jl
@@ -169,7 +169,7 @@ function status(m::CplexMathProgModel)
         Base.warn_once("CPLEX reported infeasible or unbounded. Set CPX_PARAM_REDUCE=1 to check
                         infeasibility or CPX_PARAM_REDUCE=2 to check unboundedness.")
         :InfeasibleOrUnbounded
-    elseif contains(string(ret), "ABORT")
+    elseif contains(string(ret), "TIME_LIM")
         :UserLimit
     else
         ret


### PR DESCRIPTION
Since ABORT is only in 

`:CPX_STAT_ABORT_TIME_LIM`

but TIME_LIM is in all those

```
:CPX_STAT_ABORT_TIME_LIM
:CPXMIP_TIME_LIM_FEAS,
:CPXMIP_TIME_LIM_INFEAS,
```

This should fix the issue mentioned by @mlubin in #77