### PR TITLE
Change to Compat.ASCIIString

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,6 +1,6 @@
 using Compat
 
-import Compat: String
+import Compat: ASCIIString
 
 depsfile = joinpath(dirname(@__FILE__),"deps.jl")
 if isfile(depsfile)
@@ -21,7 +21,7 @@ end
 
 cpxvers = ["125","1251","1260","1261","1262","1263"]
 
-libnames = String["cplex"]
+libnames = ASCIIString["cplex"]
 for v in reverse(cpxvers)
     if is_apple()
         push!(libnames, "libcplex$v.dylib")

--- a/src/CPLEX.jl
+++ b/src/CPLEX.jl
@@ -3,7 +3,7 @@ __precompile__()
 module CPLEX
 
     using Compat
-    import Compat.String
+    import Compat.ASCIIString
 
     if is_apple()
         Libdl.dlopen("libstdc++",Libdl.RTLD_GLOBAL)

--- a/src/CplexSolverInterface.jl
+++ b/src/CplexSolverInterface.jl
@@ -64,7 +64,7 @@ function setparameters!(s::CplexMathProgModel; mpboptions...)
     end
 end
 
-function loadproblem!(m::CplexMathProgModel, filename::AbstractString)
+function loadproblem!(m::CplexMathProgModel, filename::ASCIIString)
    read_model(m.inner, filename)
    prob_type = get_prob_type(m.inner)
    if prob_type in [:MILP,:MIQP, :MIQCP]
@@ -107,7 +107,7 @@ function loadproblem!(m::CplexMathProgModel, A, collb, colub, obj, rowlb, rowub,
   set_sense!(m.inner, sense)
 end
 
-writeproblem(m::CplexMathProgModel, filename::AbstractString) = write_model(m.inner, filename)
+writeproblem(m::CplexMathProgModel, filename::ASCIIString) = write_model(m.inner, filename)
 
 getvarLB(m::CplexMathProgModel) = get_varLB(m.inner)
 setvarLB!(m::CplexMathProgModel, l) = set_varLB!(m.inner, l)

--- a/src/cpx_env.jl
+++ b/src/cpx_env.jl
@@ -17,7 +17,7 @@ function is_valid(env::Env)
     env.ptr != C_NULL
 end
 
-function set_logfile(env::Env, filename::String)
+function set_logfile(env::Env, filename::ASCIIString)
   fp = @cpx_ccall(fopen, Ptr{Void}, (Ptr{Cchar}, Ptr{Cchar}), filename, "w")
   if fp == C_NULL
     error("CPLEX: Error setting logfile")
@@ -41,7 +41,7 @@ end
 
 type CplexError <: Exception
   code::Int
-  msg::String
+  msg::ASCIIString
 
   function CplexError(env::Env, code::Integer)
     new(convert(Cint, code), get_error_msg(env, code))

--- a/src/cpx_highlevel.jl
+++ b/src/cpx_highlevel.jl
@@ -1,7 +1,7 @@
 # High level model construction
 
 function cplex_model(env::Env;    # solver environment
-    name::String="",          # model name
+    name::ASCIIString="",          # model name
     sense::Symbol=:Min,       # :minimize or :maximize
     H::CoeffMat=emptyfmat,         # quadratic coefficient matrix
     f::FVec=emptyfvec,             # linear coefficient vector

--- a/src/cpx_model.jl
+++ b/src/cpx_model.jl
@@ -14,7 +14,7 @@ function Model(env::Env, lp::Ptr{Void})
     model
 end
 
-function Model(env::Env, name::String)
+function Model(env::Env, name::ASCIIString)
     @assert is_valid(env)
     stat = Array(Cint, 1)
     tmp = @cpx_ccall(createprob, Ptr{Void}, (Ptr{Void}, Ptr{Cint}, Ptr{Cchar}), env.ptr, stat, name)
@@ -42,14 +42,14 @@ function _Model(env::Env)
     return model
 end
 
-function read_model(model::Model, filename::String)
+function read_model(model::Model, filename::ASCIIString)
     stat = @cpx_ccall(readcopyprob, Cint, (Ptr{Void}, Ptr{Void}, Ptr{Cchar}, Ptr{Cchar}), model.env.ptr, model.lp, filename, C_NULL)
     if stat != 0
         throw(CplexError(model.env, stat))
     end
 end
 
-function write_model(model::Model, filename::String)
+function write_model(model::Model, filename::ASCIIString)
     if endswith(filename,".mps")
         filetype = "MPS"
     elseif endswith(filename,".lp")

--- a/src/cpx_params.jl
+++ b/src/cpx_params.jl
@@ -29,7 +29,7 @@ function get_param_type(env::Env, indx::Int)
   return ret
 end
 
-get_param_type(env::Env, name::String) = get_param_type(env, paramName2Indx[name])
+get_param_type(env::Env, name::ASCIIString) = get_param_type(env, paramName2Indx[name])
 
 function set_param!(env::Env, _pindx::Int, val, ptype::Symbol)
   pindx = convert(Cint, _pindx)
@@ -53,7 +53,7 @@ end
 
 set_param!(env::Env, pindx::Int, val) = set_param!(env, pindx, val, get_param_type(env, pindx))
 
-set_param!(env::Env, pname::String, val) = set_param!(env, paramName2Indx[pname], val)
+set_param!(env::Env, pname::ASCIIString, val) = set_param!(env, paramName2Indx[pname], val)
 
 # set_params!(env::Env, args...)
 #   for (name, v) in args
@@ -100,7 +100,7 @@ end
 
 get_param(env::Env, pindx::Int) = get_param(env, pindx, get_param_type(env, pindx))
 
-get_param(env::Env, pname::String) = get_param(env, paramName2Indx[pname])
+get_param(env::Env, pname::ASCIIString) = get_param(env, paramName2Indx[pname])
 
 tune_param(model::Model) = tune_param(model, Dict(), Dict(), Dict())
 

--- a/src/cpx_vars.jl
+++ b/src/cpx_vars.jl
@@ -199,7 +199,7 @@ function num_var(model::Model)
     return(nvar)
 end
 
-function set_varname!(model::Model, idx::Integer, name::AbstractString)
+function set_varname!(model::Model, idx::Integer, name::ASCIIString)
     s = bytestring(name)
 
     stat = @cpx_ccall(chgcolname, Cint, (


### PR DESCRIPTION
This pull request improves the deprecation of ASCIIString introduced in https://github.com/JuliaOpt/CPLEX.jl/pull/82 addressses and closes https://github.com/JuliaOpt/CPLEX.jl/issues/86.

Compat.ASCIIString is an alias for `ASCIIString` on Julia 0.4 and `String` on Julia 0.5.

CPLEX seems to handle non-ascii strings pretty well. The param getters and setters fail with key not found due to the `paramName2Index` dictionary lookup. Setting the model and variable name with non-ascii strings and writing them to a non-ascii filename all seems to work.

The only issues I ran into were not ASCIIString related

 - `set_logfile` gives a `no method matching unsafe_convert(::Ptr{Void}, ::CPLEX.Env)`

and

 - `read_model(m::Model, filename::String)` gives `CPLEX Error 1434` which is a [bad number](http://www-eio.upc.edu/lceio/manuals/cplex-11/html/refcallablelibrary/html/macros/CPXERR_BAD_NUMBER.html) error. This seems to trigger when variable names have spaces in them.

@mlubin @tkelman 