### PR TITLE
fix return status when exiting from callbacks

### DIFF
--- a/src/CplexSolverInterface.jl
+++ b/src/CplexSolverInterface.jl
@@ -200,7 +200,7 @@ function status(m::CplexMathProgModel)
         Base.warn_once("CPLEX reported infeasible or unbounded. Set CPX_PARAM_REDUCE=1 to check
                         infeasibility or CPX_PARAM_REDUCE=2 to check unboundedness.")
         :InfeasibleOrUnbounded
-    elseif contains(string(ret), "TIME_LIM")
+    elseif contains(string(ret), "TIME_LIM") || contains(string(ret), "MIP_ABORT")
         :UserLimit
     else
         ret


### PR DESCRIPTION
This was causing CPLEX to fail here: https://github.com/JuliaOpt/JuMP.jl/blob/58dc38dae598652d1fee460666f31f0e5c962e05/test/callback.jl#L304