### PR TITLE
fix multiple loadproblem! calls

### DIFF
--- a/src/CplexSolverInterface.jl
+++ b/src/CplexSolverInterface.jl
@@ -20,7 +20,7 @@ function CplexMathProgModel(;options...)
         set_param!(env, string(name), value)
     end
 
-    m = CplexMathProgModel(_Model(env), nothing, nothing, nothing, nothing, nothing, nothing, NaN)
+    m = CplexMathProgModel(Model(env), nothing, nothing, nothing, nothing, nothing, nothing, NaN)
     return m
 end
 
@@ -76,6 +76,8 @@ function loadproblem!(m::CplexMathProgModel, filename::String)
 end
 
 function loadproblem!(m::CplexMathProgModel, A, collb, colub, obj, rowlb, rowub, sense)
+  # throw away old model but keep env
+  m.inner = Model(m.inner.env)
   add_vars!(m.inner, float(obj), float(collb), float(colub))
 
   neginf = typemin(eltype(rowlb))

--- a/src/cpx_env.jl
+++ b/src/cpx_env.jl
@@ -1,5 +1,7 @@
 type Env
     ptr::Ptr{Void}
+    num_models::Int
+    finalize_called::Bool
 
     function Env()
       stat = Array(Cint, 1)
@@ -7,7 +9,15 @@ type Env
       if tmp == C_NULL
           error("CPLEX: Error creating environment")
       end
-      new(tmp)
+      env = new(tmp, 0, false)
+      finalizer(env, env -> begin
+                                if env.num_models == 0
+                                    close_CPLEX(env)
+                                else
+                                    env.finalize_called = true
+                                end
+                            end)
+      env
     end
 end
 
@@ -16,6 +26,27 @@ unsafe_convert(ty::Type{Ptr{Void}}, env::Env) = convert(ty, env)
 
 function is_valid(env::Env)
     env.ptr != C_NULL
+end
+
+function notify_new_model(env::Env)
+    env.num_models += 1
+end
+
+function notify_freed_model(env::Env)
+    @assert env.num_models > 0
+    env.num_models -= 1
+    if env.num_models <= 0 && env.finalize_called
+        close_CPLEX(env)
+    end
+end
+
+function close_CPLEX(env::Env)
+    tmp = Ptr{Void}[env.ptr]
+    stat = @cpx_ccall(closeCPLEX, Cint, (Ptr{Void},), tmp)
+    env.ptr = C_NULL
+    if stat != 0
+        throw(CplexError(env, stat))
+    end
 end
 
 function set_logfile(env::Env, filename::String)

--- a/test/env.jl
+++ b/test/env.jl
@@ -1,0 +1,14 @@
+using CPLEX, MathProgBase, Base.Test
+
+@testset "Use loadproblem! twice" begin
+    solver = CplexSolver()
+    # Check that the env for each model is the same
+    m = MathProgBase.LinearQuadraticModel(solver)
+    env = m.inner.env
+    MathProgBase.loadproblem!(m, [1 0], [1, 1], [1, Inf], [1, 0], [0], [Inf], :Min)
+    @test m.inner.env === env
+    @test CPLEX.is_valid(env)
+    MathProgBase.loadproblem!(m, [0 1], [-Inf, 1], [1, 1], [0, 1], [-Inf], [0], :Min)
+    @test m.inner.env === env
+    @test CPLEX.is_valid(env)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ tests = ["low_level_api",
          "qp_01",
          "qp_02",
          "qcqp_01",
+         "env",
          "mathprog"]
 
 for t in tests


### PR DESCRIPTION
I first tried the `finalize_env` mechanism used in Gurobi.jl but it gave me segfault because it happened that the model that is thrown away gets gc'd second which cause it to be freed after the environment has already been freed by the new model that was gc'd first.