### PR TITLE
Fix bug that occurs when switching between integer and non-integer models

### DIFF
--- a/test/problemtype.jl
+++ b/test/problemtype.jl
@@ -1,0 +1,24 @@
+using CPLEX
+using Base.Test
+
+@testset "Changing variable type" begin
+    # linear -> mixed integer -> linear
+    m = CPLEX.CplexMathProgModel()
+    CPLEX.loadproblem!(m, [1 1; 1 0], [0, 0], [Inf, 1], [1, 2], [1.33, -Inf], [Inf, 0.5], :Min)
+
+    @test CPLEX.get_prob_type(m.inner) == :LP
+    CPLEX.optimize!(m)
+    @test_approx_eq CPLEX.getsolution(m) [0.5, 0.83]
+
+    CPLEX.setvartype!(m, [:Cont, :Bin])
+
+    @test CPLEX.get_prob_type(m.inner) == :MILP
+    CPLEX.optimize!(m)
+    @test_approx_eq CPLEX.getsolution(m) [0.33, 1]
+
+    CPLEX.setvartype!(m, [:Cont, :Cont])
+
+    @test CPLEX.get_prob_type(m.inner) == :LP
+    CPLEX.optimize!(m)
+    @test_approx_eq CPLEX.getsolution(m) [0.5, 0.83]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,9 @@ tests = ["low_level_api",
          "qp_02",
          "qcqp_01",
          "env",
-         "mathprog"]
+         "problemtype",
+         "mathprog"
+         ]
 
 for t in tests
     fp = "$(t).jl"


### PR DESCRIPTION
Changing the variable type doesn't automatically change the problem type. There needs to be an explicit call to `chgprobtype`.

Closes https://github.com/JuliaOpt/CPLEX.jl/issues/110

Passes all tests locally.