### PR TITLE
Fix handling of MIQP problem type. Fixes #115

### DIFF
--- a/src/cpx_model.jl
+++ b/src/cpx_model.jl
@@ -97,10 +97,10 @@ end
 const type_map = Dict(
      0 => :LP,
      1 => :MILP,
-     3 => :MILP, # actually fixed milp
+     3 => :FIXEDMILP, # actually fixed milp
      5 => :QP,
      7 => :MIQP,
-     8 => :MIQP,
+     8 => :FIXEDMIQP,
     10 => :QCP,
     11 => :MIQCP
 )
@@ -111,7 +111,7 @@ const rev_prob_type_map = Dict(
     :FIXEDMILP  => 3,
     :QP    => 5,
     :MIQP  => 7,
-    :MIQP  => 8,
+    :FIXEDMIQP  => 8,
     :QCP   => 10,
     :MIQCP => 11
 )

--- a/test/miqcp.jl
+++ b/test/miqcp.jl
@@ -1,0 +1,44 @@
+# QCP example
+#    minimize x^2
+#
+#    s.t.  x >= 0.1
+#          x ∈ {0, 1}
+#
+#    solution: (0.1) objv = 0.01
+
+using CPLEX
+using Base.Test
+
+# ===========================================
+
+m = CPLEX.CplexMathProgModel()
+CPLEX.loadproblem!(m, Array(Float64, (0,1)), [0.1], [Inf], [0], Float64[], Float64[], :Min)
+@test CPLEX.get_prob_type(m.inner) == :LP
+CPLEX.setquadobj!(m, [2]')
+@test CPLEX.get_prob_type(m.inner) == :QP
+CPLEX.optimize!(m)
+@test isapprox(CPLEX.getobjval(m), 0.5*0.1*2*0.1)
+
+# ===========================================
+
+m2 = CPLEX.CplexMathProgModel()
+CPLEX.loadproblem!(m2, Array(Float64, (0,1)), [0.1], [Inf], [0], Float64[], Float64[], :Min)
+@test CPLEX.get_prob_type(m2.inner) == :LP
+CPLEX.setvartype!(m2, [:Bin])
+@test CPLEX.get_prob_type(m2.inner) == :MILP
+CPLEX.setquadobj!(m2, [2]')
+@test CPLEX.get_prob_type(m2.inner) == :MIQP
+CPLEX.optimize!(m2)
+@test isapprox(CPLEX.getobjval(m2), 0.5*1*2*1)
+
+# ===========================================
+
+m3 = CPLEX.CplexMathProgModel()
+CPLEX.loadproblem!(m3, Array(Float64, (0,1)), [0.1], [Inf], [0], Float64[], Float64[], :Min)
+@test CPLEX.get_prob_type(m3.inner) == :LP
+CPLEX.setquadobj!(m3, [2]')
+@test CPLEX.get_prob_type(m3.inner) == :QP
+CPLEX.setvartype!(m3, [:Bin])
+@test CPLEX.get_prob_type(m3.inner) == :MIQP
+CPLEX.optimize!(m3)
+@test isapprox(CPLEX.getobjval(m3), 0.5*1*2*1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ tests = ["low_level_api",
          "qcqp_01",
          "env",
          "problemtype",
+         "miqcp",
          "mathprog"
          ]
 


### PR DESCRIPTION
Because the `rev_type_map` dict had two entries for `:MIQP` it was actually trying to set it as a fixed MIQP.