### PR TITLE
Fix handling of SOS and problem type. Fixes #116

### DIFF
--- a/src/CplexSolverInterface.jl
+++ b/src/CplexSolverInterface.jl
@@ -238,7 +238,9 @@ function setvartype!(m::CplexMathProgModel, v::Vector{Symbol})
     target_int = all(x->isequal(x,:Cont), v)
     prob_type = get_prob_type(m.inner)
     if target_int
-        if !m.inner.has_sos # if it has sos we need to keep has_int==true and the MI(prob_type) version.
+        if m.inner.has_sos # if it has sos we need to keep has_int==true and the MI(prob_type) version.
+            set_vartype!(m.inner, map(x->rev_var_type_map[x], v))    
+        else
             m.inner.has_int = false
             if !(prob_type in [:LP,:QP,:QCP])
                 toggleproblemtype!(m)

--- a/src/CplexSolverInterface.jl
+++ b/src/CplexSolverInterface.jl
@@ -238,9 +238,11 @@ function setvartype!(m::CplexMathProgModel, v::Vector{Symbol})
     target_int = all(x->isequal(x,:Cont), v)
     prob_type = get_prob_type(m.inner)
     if target_int
-        m.inner.has_int = false
-        if !(prob_type in [:LP,:QP,:QCP])
-            toggleproblemtype!(m)
+        if !m.inner.has_sos # if it has sos we need to keep has_int==true and the MI(prob_type) version.
+            m.inner.has_int = false
+            if !(prob_type in [:LP,:QP,:QCP])
+                toggleproblemtype!(m)
+            end
         end
     else
         if prob_type in [:LP,:QP,:QCP]

--- a/src/cpx_constrs.jl
+++ b/src/cpx_constrs.jl
@@ -345,6 +345,7 @@ function add_sos!(model::Model, sostype::Symbol, idx::Vector{Int}, weight::Vecto
         throw(CplexError(model.env, stat))
     end
     model.has_int = true
+    model.has_sos = true
     return nothing
 end
 

--- a/src/cpx_model.jl
+++ b/src/cpx_model.jl
@@ -3,13 +3,14 @@ type Model
     lp::Ptr{Void} # Cplex problem (lp)
     has_int::Bool # problem has integer variables?
     has_qc::Bool # problem has quadratic constraints?
+    has_sos::Bool # problem has Special Ordered Sets?
     callback::Any
     terminator::Vector{Cint}
 end
 
 function Model(env::Env, lp::Ptr{Void})
     notify_new_model(env)
-    model = Model(env, lp, false, false, nothing, Cint[0])
+    model = Model(env, lp, false, false, false, nothing, Cint[0])
     finalizer(model, m -> begin
                               free_problem(m)
                               notify_freed_model(env)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ tests = ["low_level_api",
          "qp_02",
          "qcqp_01",
          "env",
+         "sos",
          "problemtype",
          "mathprog"
          ]

--- a/test/sos.jl
+++ b/test/sos.jl
@@ -1,0 +1,39 @@
+using CPLEX, Base.Test
+
+m = CPLEX.CplexMathProgModel()
+CPLEX.loadproblem!(m,
+    [1 2 3 0 0 0 0 0 -1 0; 0 0 0 5 4 7 2 1 0 -1], # constraint matrix
+    fill(-Inf, 10), # variable lb
+    fill(Inf, 10), # variable ub
+    vcat(zeros(8), ones(2)), # objective vector
+    [0, 0], # constraint lb
+    [0, 0], # constraint ub
+    :Max)
+@test CPLEX.get_prob_type(m.inner) == :LP
+
+CPLEX.setvartype!(m, vcat(fill(:Bin, 8), fill(:Cont, 2)))
+@test CPLEX.get_prob_type(m.inner) == :MILP
+
+CPLEX.addsos1!(m, [1,2,3], [1.0,2.0,3.0])
+CPLEX.addsos2!(m, [4,5,6,7,8], [5.0, 4.0, 7.0, 2.0, 1.0])
+@test CPLEX.get_prob_type(m.inner) == :MILP
+
+CPLEX.optimize!(m)
+
+@test isapprox(CPLEX.getobjval(m), 15.0)
+sol = CPLEX.getsolution(m)
+@test isapprox(sol[9],  3.0)
+@test isapprox(sol[10], 12.0)
+
+# ======================================
+
+m2 = CPLEX.CplexMathProgModel()
+CPLEX.loadproblem!(m2, Array(Float64, (0,3)), [-Inf, -Inf, -Inf], [1,1,2], [2,1,1], Float64[], Float64[], :Max)
+@test CPLEX.get_prob_type(m2.inner) == :LP
+
+CPLEX.addsos1!(m2, [1,2], [1.0,2.0])
+CPLEX.addsos1!(m2, [1,3], [1.0,2.0])
+@test CPLEX.get_prob_type(m2.inner) == :MILP
+
+CPLEX.optimize!(m2)
+@test isapprox(CPLEX.getobjval(m2), 3.0)

--- a/test/sos.jl
+++ b/test/sos.jl
@@ -3,8 +3,8 @@ using CPLEX, Base.Test
 m = CPLEX.CplexMathProgModel()
 CPLEX.loadproblem!(m,
     [1 2 3 0 0 0 0 0 -1 0; 0 0 0 5 4 7 2 1 0 -1], # constraint matrix
-    fill(-Inf, 10), # variable lb
-    fill(Inf, 10), # variable ub
+    [0, 0, 0, 0, 0, 0, 0, 0, -Inf, -Inf], # variable lb
+    [2, 2, 2, 2, 2, 2, 2, 2, Inf, Inf], # variable ub
     vcat(zeros(8), ones(2)), # objective vector
     [0, 0], # constraint lb
     [0, 0], # constraint ub
@@ -24,6 +24,16 @@ CPLEX.optimize!(m)
 sol = CPLEX.getsolution(m)
 @test isapprox(sol[9],  3.0)
 @test isapprox(sol[10], 12.0)
+
+CPLEX.setvartype!(m, fill(:Cont, 10))
+@test CPLEX.get_prob_type(m.inner) == :MILP
+
+CPLEX.optimize!(m)
+
+@test isapprox(CPLEX.getobjval(m), 30.0)
+sol = CPLEX.getsolution(m)
+@test isapprox(sol[9],  6.0)
+@test isapprox(sol[10], 24.0)
 
 # ======================================
 


### PR DESCRIPTION
In a model with SOS constraints but no explicit binary or integer variables, changing the problem type to `:LP` discarded the SOS constraints.