### PR TITLE
WIP: adding cplex annotations to be used for bender decomposition

### DIFF
--- a/src/CPLEX.jl
+++ b/src/CPLEX.jl
@@ -18,8 +18,10 @@ module CPLEX
     # Standard LP interface
     importall MathProgBase.SolverInterface
 
-    # BlockJuMP decomposition interface
-    importall BlockJuMP.BlockSolverInterface
+    # BlockJuMP Interface
+    if Pkg.installed("BlockJuMP") != nothing
+        importall BlockJuMP.BlockSolverInterface
+    end
 
     # exported functions
     # export is_valid,

--- a/src/CPLEX.jl
+++ b/src/CPLEX.jl
@@ -18,6 +18,9 @@ module CPLEX
     # Standard LP interface
     importall MathProgBase.SolverInterface
 
+    # BlockJuMP decomposition interface
+    importall BlockJuMP.BlockSolverInterface
+
     # exported functions
     # export is_valid,
     #        set_logfile,

--- a/src/CPLEX.jl
+++ b/src/CPLEX.jl
@@ -18,11 +18,6 @@ module CPLEX
     # Standard LP interface
     importall MathProgBase.SolverInterface
 
-    # BlockJuMP Interface
-    if Pkg.installed("BlockJuMP") != nothing
-        importall BlockJuMP.BlockSolverInterface
-    end
-
     # exported functions
     # export is_valid,
     #        set_logfile,

--- a/src/cpx_solve.jl
+++ b/src/cpx_solve.jl
@@ -36,6 +36,36 @@ function set_branching_priority(model::Model, indices::Vector{Cint}, priority::V
     return nothing
 end
 
+
+function newlongannotation(model::Model, name::String, defval::Clong)
+    stat = @cpx_ccall(newlongannotation, Cint, (
+                      Ptr{Void},
+                      Ptr{Void},
+                      Ptr{Cchar},
+                      Clong),
+                      model.env.ptr, model.lp, name, defval)
+    stat == 0 || throw(CplexError(model.env, stat))
+
+    return nothing
+end
+
+function setlongannotations(model::Model, idx::Cint, objtype::Cint, cnt::Cint, indexArr::Array{Cint},
+                valArr::Array{Clong})
+    stat = @cpx_ccall(setlongannotations, Cint, (
+                Ptr{Void},
+                Ptr{Void},
+                Cint,
+                Cint,
+                Cint,
+                Ptr{Void},
+                Ptr{Void}),
+                model.env.ptr, model.lp, idx, objtype, cnt, indexArr, valArr)
+    stat == 0 || throw(CplexError(model.env, stat))
+    return nothing
+end
+
+export setlongannotations, newlongannotation
+
 function get_objval(model::Model)
   objval = Array(Cdouble, 1)
   stat = @cpx_ccall(getobjval, Cint, (


### PR DESCRIPTION
We are implementing a new package BlockJuMP to define block decompositions for MIPs. It will also  define oracles to the solve the subproblems and other useful directives. See an example here: https://realopt.github.io/BlockJuMP.jl/latest/basic.html.

Cplex is one of the solvers that is already supporting benders decomposition and we would like to use it with BlockJuMP. What do you think about it ?