### PR TITLE
Add CPLEX_STUDIO_BINARIES ENV on unix #128

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ NOTE: CPLEX [does not officially support linking to their dynamic C library](htt
 
 2. Once CPLEX is installed on your machine, point the `LD_LIBRARY_PATH` variable to the directory containing the CPLEX library by adding, for example, ``export LD_LIBRARY_PATH="/path/to/cplex/bin/x86-64_linux":$LD_LIBRARY_PATH`` to your start-up file (e.g. ``.bash_profile``, [adding library path on Ubuntu](http://stackoverflow.com/questions/13428910/how-to-set-the-environmental-variable-ld-library-path-in-linux for a)). On linux, make sure this directory contains ``libcplexXXX.so`` where ``XXX`` is stands for the version number; on OS-X the file should be named ``libcplexXXX.dylib``. Alternatively, you can also use the `CPLEX_STUDIO_BINARIES` environment variable as follows:
   ```
-  CPLEX_STUDIO_BINARIES=/path/to/cplex/bin/x86-64_linux julia -e 'Pkg.build("CPLEX")'
+  $ CPLEX_STUDIO_BINARIES=/path/to/cplex/bin/x86-64_linux julia -e 'Pkg.add("CPLEX"); Pkg.build("CPLEX")'
   ```
 
 3. At the Julia prompt, run

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ NOTE: CPLEX [does not officially support linking to their dynamic C library](htt
 
 1. First, you must obtain a copy of the CPLEX software and a license; trial versions and academic licenses are available [here](http://www-01.ibm.com/software/websphere/products/optimization/cplex-studio-preview-edition/).
 
-2. Once CPLEX is installed on your machine, point the LD_LIBRARY_PATH variable to the directory containing the CPLEX library by adding, for example, ``export LD_LIBRARY_PATH="/path/to/cplex/bin/x86-64_linux":$LD_LIBRARY_PATH`` to your start-up file (e.g. ``.bash_profile``, [adding library path on Ubuntu](http://stackoverflow.com/questions/13428910/how-to-set-the-environmental-variable-ld-library-path-in-linux for a)). On linux, make sure this directory contains ``libcplexXXX.so`` where ``XXX`` is stands for the version number; on OS-X the file should be named ``libcplexXXX.dylib``.
+2. Once CPLEX is installed on your machine, point the `LD_LIBRARY_PATH` variable to the directory containing the CPLEX library by adding, for example, ``export LD_LIBRARY_PATH="/path/to/cplex/bin/x86-64_linux":$LD_LIBRARY_PATH`` to your start-up file (e.g. ``.bash_profile``, [adding library path on Ubuntu](http://stackoverflow.com/questions/13428910/how-to-set-the-environmental-variable-ld-library-path-in-linux for a)). On linux, make sure this directory contains ``libcplexXXX.so`` where ``XXX`` is stands for the version number; on OS-X the file should be named ``libcplexXXX.dylib``. Alternatively, you can also use the `CPLEX_STUDIO_BINARIES` environment variable as follows:
+  ```
+  CPLEX_STUDIO_BINARIES=/path/to/cplex/bin/x86-64_linux julia -e 'Pkg.build("CPLEX")'
+  ```
 
 3. At the Julia prompt, run
   ```

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -15,6 +15,8 @@ if is_apple()
     Libdl.dlopen("libstdc++",Libdl.RTLD_GLOBAL)
 end
 
+base_env = "CPLEX_STUDIO_BINARIES"
+
 cpxvers = ["1260","1261","1262","1263","1270", "1271"]
 
 libnames = String["cplex"]
@@ -23,13 +25,16 @@ for v in reverse(cpxvers)
         push!(libnames, "libcplex$v.dylib")
     elseif is_unix()
         push!(libnames, "libcplex$v.so")
+        if haskey(ENV, base_env)
+            push!(libnames, joinpath(ENV[base_env], "libcplex$v.so"))
+        end
     end
 end
 
 wincpxvers = ["126","1261","1262","1263","127","1270","1271"]
 if is_windows()
     for v in reverse(wincpxvers)
-        env = "CPLEX_STUDIO_BINARIES$v"
+        env = base_env * v
         if haskey(ENV,env)
             for d in split(ENV[env],';')
                 contains(d,"cplex") || continue


### PR DESCRIPTION
Fix #128 by using the `CPLEX_STUDIO_BINARIES` environment variable on Unix so that it is possible to do:
```
$ CPLEX_STUDIO_BINARIES=/path/to/cplex/bin/x86-64_linux julia -e 'Pkg.build("CPLEX")'
```