### PR TITLE
disable JuMPfunctions on Julia 0.6

### DIFF
--- a/src/CPLEX.jl
+++ b/src/CPLEX.jl
@@ -106,7 +106,9 @@ module CPLEX
     include("cpx_highlevel.jl")
 
     include("CplexSolverInterface.jl")
-    if isdir(Pkg.dir("JuMP"))
+    # These are undocumented JuMP extensions for CPLEX which
+    # will need to be hosted in a separate package for Julia 0.6 and later.
+    if isdir(Pkg.dir("JuMP")) && VERSION < v"0.6-"
         try
             eval(current_module(), Expr(:import,:JuMP))
             include("JuMPfunctions.jl")


### PR DESCRIPTION
@chriscoey has been experiencing some world age issues involving CPLEX from Pajarito.
I don't believe something like ``eval(current_module(), Expr(:import,:JuMP))`` is allowed anymore, for the same reason that we got rid of default solvers. I'd propose to disable the undocumented "JuMPfunctions" on Julia 0.6, and if they're needed they can be moved into a separate package.

@joehuchette 