### PR TITLE
specific version cutoff for escaping stdcall

### DIFF
--- a/src/cpx_common.jl
+++ b/src/cpx_common.jl
@@ -8,7 +8,7 @@ macro cpx_ccall(func, args...)
         end
     end
     if is_windows()
-        if VERSION < v"0.6-"
+        if VERSION < v"0.6.0-dev.1512" # probably julia PR #15850
             return quote
                 ccall(($f,libcplex), stdcall, $(args...))
             end


### PR DESCRIPTION
this is a bit of a guess, it may have been 18754, but this cutoff is closer to right
than the first commit after 0.5 branched