### PR TITLE
Drop Julia 0.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.5
+julia 0.6
 MathProgBase 0.5 0.8
 Compat 0.18


### PR DESCRIPTION
We can't tag a new release supporting 0.5.