### PR TITLE
Fix Libdl moved to stdlib on v0.7

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,3 +1,7 @@
+if VERSION >= v"0.7.0-DEV.3382"
+    using Libdl
+end
+
 depsfile = joinpath(dirname(@__FILE__),"deps.jl")
 if isfile(depsfile)
     rm(depsfile)

--- a/src/CPLEX.jl
+++ b/src/CPLEX.jl
@@ -2,6 +2,10 @@ __precompile__()
 
 module CPLEX
 
+    if VERSION >= v"0.7.0-DEV.3382"
+        using Libdl
+    end
+
     if is_apple()
         Libdl.dlopen("libstdc++",Libdl.RTLD_GLOBAL)
     end


### PR DESCRIPTION
Closes #159 