### PR TITLE
Update build.jl to enable Cplex 12.8 support in linux

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -17,7 +17,7 @@ end
 
 base_env = "CPLEX_STUDIO_BINARIES"
 
-cpxvers = ["1260","1261","1262","1263","1270", "1271","128"]
+cpxvers = ["1260","1261","1262","1263","1270", "1271","128","1280"]
 
 libnames = String["cplex"]
 for v in reverse(cpxvers)


### PR DESCRIPTION
The most recent download of Cplex in linux (ubuntu) has the .so file with version number "1280".