### PR TITLE
read_model - has_int and has_qc

### DIFF
--- a/src/CplexSolverInterface.jl
+++ b/src/CplexSolverInterface.jl
@@ -69,13 +69,6 @@ end
 
 function MathProgBase.loadproblem!(m::CplexMathProgModel, filename::String)
    read_model(m.inner, filename)
-   prob_type = get_prob_type(m.inner)
-   if prob_type in [:MILP,:MIQP, :MIQCP]
-      m.inner.has_int = true
-   end
-   if prob_type in [:QP, :MIQP, :QCP, :MIQCP]
-      m.inner.has_qc = true
-   end
 end
 
 function MathProgBase.loadproblem!(m::CplexMathProgModel, A, collb, colub, obj, rowlb, rowub, sense)

--- a/src/cpx_model.jl
+++ b/src/cpx_model.jl
@@ -34,6 +34,13 @@ function read_model(model::Model, filename::String)
     if stat != 0
         throw(CplexError(model.env, stat))
     end
+    prob_type = get_prob_type(model)
+    if prob_type in [:MILP,:MIQP, :MIQCP]
+        model.has_int = true
+    end
+    if prob_type in [:QP, :MIQP, :QCP, :MIQCP]
+        model.has_qc = true
+    end
 end
 
 function write_model(model::Model, filename::String)


### PR DESCRIPTION
Using read_model and optimize! on MILP get ERROR: CPLEX.CplexError(1017, "CPLEX Error  1017: Not available for mixed-integer problems.\n")
Corrections on MathProgBase.loadproblem! shouldn't be directly on read_model?