### PR TITLE
Quadratic support in MOI

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -357,9 +357,7 @@ end
 
 function LQOI.set_quadratic_objective!(model::Optimizer, I::Vector{Int}, J::Vector{Int}, V::Vector{Float64})
     @assert length(I) == length(J) == length(V)
-    #scalediagonal!(V, I, J, 0.5)
     CPLEX.add_qpterms!(model.inner, I, J, V)
-    #scalediagonal!(V, I, J, 2.0)
     return
 end
 
@@ -387,8 +385,8 @@ function LQOI.add_quadratic_constraint!(model::Optimizer,
 end
 
 function LQOI.get_quadratic_constraint(model::Optimizer, row::Int)
-    #_update_if_necessary(model)
-    affine_cols, affine_coefficients, I, J, V, _ = get_qconstr(model.inner, row)
+    affine_cols, affine_coefficients, I, J, V, _, _ = c_api_getqconstr(model.inner, row)
+    #scalediagonal!(V, I, J, 2.0)
     # note: we return 1-index columns here
     affine_cols .+= 1
     I .+= 1
@@ -397,11 +395,15 @@ function LQOI.get_quadratic_constraint(model::Optimizer, row::Int)
 end
 
 function LQOI.get_quadratic_rhs(model::Optimizer, row::Int)
-    _, _, _, _, _, rhs = get_qconstr(model.inner, row)
+    _, _, _, _, _, _, rhs = c_api_getqconstr(model.inner, row)
     return rhs
 end
 
 function LQOI.get_number_quadratic_constraints(model::Optimizer)
-    # See the definition of Optimizer.
     return CPLEX.num_qconstr(model.inner)
 end
+
+function LQOI.get_quadratic_terms_objective(model::Optimizer)
+    #TODO
+end
+

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -36,7 +36,6 @@ mutable struct Optimizer <: LQOI.LinQuadOptimizer
     LQOI.@LinQuadOptimizerBase
     env::Union{Nothing, Env}
     params::Dict{String, Any}
-    num_quadratic_constraints::Int
 
     """
         Optimizer(env = nothing; kwargs...)
@@ -367,12 +366,12 @@ end
 LQOI.solve_quadratic_problem!(model::Optimizer) = LQOI.solve_linear_problem!(model)
 
 function LQOI.get_quadratic_primal_solution!(model::Optimizer, dest)
-    dest = CPLEX.get_solution(model.inner)
+    c_api_getxqxax(model.inner, dest)
     return
 end
 
 function LQOI.get_quadratic_dual_solution!(model::Optimizer, dest)
-    dest = CPLEX.get_constr_duals(model.inner)
+    c_api_getqconstrslack(model.inner, dest)
     return
 end
 
@@ -384,7 +383,6 @@ function LQOI.add_quadratic_constraint!(model::Optimizer,
     scalediagonal!(V, I, J, 0.5)
     add_qconstr!(model.inner, ivec(affine_columns), fvec(affine_coefficients), ivec(I), ivec(J), fvec(V), sense, rhs)
     scalediagonal!(V, I, J, 2.0)
-    model.num_quadratic_constraints += 1
     return
 end
 
@@ -402,5 +400,5 @@ LQOI.get_quadratic_rhs(model::Optimizer, row::Int) = LQOI.get_rhs
 
 function LQOI.get_number_quadratic_constraints(model::Optimizer)
     # See the definition of Optimizer.
-    return model.num_quadratic_constraints
+    return CPLEX.num_qconstr(model.inner)
 end

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -388,16 +388,16 @@ end
 
 function LQOI.get_quadratic_constraint(model::Optimizer, row::Int)
     #_update_if_necessary(model)
-    affine_cols, affine_coefficients, I, J, V, _ = getqconstr(model.inner, row)
+    affine_cols, affine_coefficients, I, J, V, _ = get_qconstr(model.inner, row)
     # note: we return 1-index columns here
     affine_cols .+= 1
     I .+= 1
     J .+= 1
-    return affine_cols, affine_coefficients, sparse(I, J, V)
+    return Int.(affine_cols), affine_coefficients, sparse(I, J, V)
 end
 
 function LQOI.get_quadratic_rhs(model::Optimizer, row::Int)
-    _, _, _, _, _, rhs = getqconstr(model.inner, row)
+    _, _, _, _, _, rhs = get_qconstr(model.inner, row)
     return rhs
 end
 

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -388,7 +388,7 @@ end
 
 function LQOI.get_quadratic_constraint(model::Optimizer, row::Int)
     #_update_if_necessary(model)
-    affine_cols, affine_coefficients, I, J, V = getqconstr(model.inner, row)
+    affine_cols, affine_coefficients, I, J, V, _ = getqconstr(model.inner, row)
     # note: we return 1-index columns here
     affine_cols .+= 1
     I .+= 1
@@ -396,7 +396,10 @@ function LQOI.get_quadratic_constraint(model::Optimizer, row::Int)
     return affine_cols, affine_coefficients, sparse(I, J, V)
 end
 
-LQOI.get_quadratic_rhs(model::Optimizer, row::Int) = LQOI.get_rhs
+function LQOI.get_quadratic_rhs(model::Optimizer, row::Int)
+    _, _, _, _, _, rhs = getqconstr(model.inner, row)
+    return rhs
+end
 
 function LQOI.get_number_quadratic_constraints(model::Optimizer)
     # See the definition of Optimizer.

--- a/src/cpx_quad.jl
+++ b/src/cpx_quad.jl
@@ -187,7 +187,6 @@ function c_api_getqconstr(model::Model, row::Int)
     quadspace = -quadsurplus_p[]
     linind = fill(Cint(0), linspace)
     linval = fill(Cdouble(0.0), linspace)
-    linsurplus_p = Ref{Cint}()
     quadrow = fill(Cint(0), quadspace)
     quadcol = fill(Cint(0), quadspace)
     quadval = fill(Cdouble(0.0), quadspace)

--- a/src/cpx_quad.jl
+++ b/src/cpx_quad.jl
@@ -152,12 +152,8 @@ function add_qconstr!(model::Model, lind::Vector, lval::Vector, qr::Vector, qc::
 end
 
 function num_qconstr(model::Model)
-    ncons = @cpx_ccall(getnumqconstrs, Cint, (
-                       Ptr{Cvoid},
-                       Ptr{Cvoid}
-                       ),
-                       model.env.ptr, model.lp)
-    return ncons
+    return @cpx_ccall(getnumqconstrs, Cint, (Ptr{Cvoid}, Ptr{Cvoid}),
+                      model.env.ptr, model.lp)
 end
 
 function c_api_getqconstr(model::Model, row::Int)
@@ -213,4 +209,43 @@ function c_api_getqconstr(model::Model, row::Int)
               "non-zero elements than expected.")
     end
     return linind, linval, quadrow, quadcol, quadval, sense_p[], rhs_p[]
+end
+
+function c_api_getquad(model::Model)
+    num_variables = num_var(model)
+    # In the first call, we ask CPLEX how many non-zero elements there are.
+    surplus_p = Ref{Cint}()
+    stat = @cpx_ccall(
+        getquad,
+        Cint, (
+             Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint},
+             Ptr{Cint}, Ptr{Cint}, Ptr{Float64},
+             Cint, Ptr{Cint}, Cint, Cint),
+             model.env.ptr, model.lp, C_NULL,
+             C_NULL, C_NULL, C_NULL,
+             0, surplus_p, 0, num_variables - 1)
+    # In the second call, we initialize arrays to contain the number of
+    # non-zero elements computed in the first part and then actually query the
+    # coefficients.
+    nzcnt_p = Ref{Cint}()
+    qmatbeg = fill(Cint(0), num_variables)
+    qmatind = fill(Cint(0), -surplus_p[])
+    qmatval = fill(0.0, -surplus_p[])
+    stat = @cpx_ccall(
+        getquad,
+        Cint, (
+            Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint},
+            Ptr{Cint}, Ptr{Cint}, Ptr{Float64},
+            Cint, Ptr{Cint}, Cint, Cint),
+        model.env.ptr, model.lp, nzcnt_p,
+        qmatbeg, qmatind, qmatval,
+        -surplus_p[], surplus_p, 0, num_variables - 1)
+    if stat != 0
+        throw(CplexError(model.env, stat))
+    end
+    if surplus_p[] < 0 || nzcnt_p[] != length(qmatind)
+        error("Unable to query quadratic constraint, there were more " *
+              "non-zero elements than expected.")
+    end
+    return qmatbeg, qmatind, qmatval
 end

--- a/src/cpx_solve.jl
+++ b/src/cpx_solve.jl
@@ -173,6 +173,21 @@ function c_api_getpi(model::Model, p::FVec)
     end
 end
 
+function c_api_getqconstrslack(model::Model, p::FVec)
+    ncons = num_qconstr(model)
+    stat = @cpx_ccall(getqconstrslack, Cint, (
+                      Ptr{Cvoid},
+                      Ptr{Cvoid},
+                      Ptr{Cdouble},
+                      Cint,
+                      Cint
+                      ),
+                      model.env.ptr, model.lp, p, 0, ncons-1)
+    if stat != 0
+       throw(CplexError(model.env, stat))
+    end
+end
+
 function get_constr_duals(model::Model)
     ncons = num_constr(model)
     p = Vector{Cdouble}(undef, ncons)
@@ -190,6 +205,21 @@ function c_api_getax(model::Model, Ax::FVec)
                       Cint
                       ),
                       model.env.ptr, model.lp, Ax, 0, ncons-1)
+    if stat != 0
+      throw(CplexError(model.env, stat))
+    end
+end
+
+function c_api_getxqxax(model::Model, xqxax::FVec)
+    ncons = num_qconstr(model)
+    stat = @cpx_ccall(getxqxax, Cint, (
+                      Ptr{Cvoid},
+                      Ptr{Cvoid},
+                      Ptr{Cdouble},
+                      Cint,
+                      Cint
+                      ),
+                      model.env.ptr, model.lp, xqxax, 0, ncons-1)
     if stat != 0
       throw(CplexError(model.env, stat))
     end

--- a/src/cpx_solve.jl
+++ b/src/cpx_solve.jl
@@ -173,7 +173,7 @@ function c_api_getpi(model::Model, p::FVec)
     end
 end
 
-function c_api_getqconstrslack(model::Model, p::FVec)
+function c_api_getqconstrslack(model::Model, dest::Vector{Float64})
     ncons = num_qconstr(model)
     stat = @cpx_ccall(getqconstrslack, Cint, (
                       Ptr{Cvoid},
@@ -182,7 +182,7 @@ function c_api_getqconstrslack(model::Model, p::FVec)
                       Cint,
                       Cint
                       ),
-                      model.env.ptr, model.lp, p, 0, ncons-1)
+                      model.env.ptr, model.lp, dest, 0, ncons-1)
     if stat != 0
        throw(CplexError(model.env, stat))
     end
@@ -210,7 +210,7 @@ function c_api_getax(model::Model, Ax::FVec)
     end
 end
 
-function c_api_getxqxax(model::Model, xqxax::FVec)
+function c_api_getxqxax(model::Model, dest::Vector{Float64})
     ncons = num_qconstr(model)
     stat = @cpx_ccall(getxqxax, Cint, (
                       Ptr{Cvoid},
@@ -219,7 +219,7 @@ function c_api_getxqxax(model::Model, xqxax::FVec)
                       Cint,
                       Cint
                       ),
-                      model.env.ptr, model.lp, xqxax, 0, ncons-1)
+                      model.env.ptr, model.lp, dest, 0, ncons-1)
     if stat != 0
       throw(CplexError(model.env, stat))
     end

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -10,8 +10,6 @@ const CONFIG = MOIT.TestConfig()
 @testset "Unit Tests" begin
     MOIT.unittest(SOLVER, CONFIG, [
         "solve_affine_interval",  # not implemented
-        "solve_qp_edge_cases",    # not implemented
-        "solve_qcp_edge_cases",   # not implemented
         "solve_objbound_edge_cases"
     ])
     @testset "solve_affine_interval" begin

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -51,6 +51,13 @@ end
     end
 end
 
+@testset "Quadratic tests" begin
+    MOIT.contquadratictest(
+        SOLVER,
+        MOIT.TestConfig(atol=1e-3, rtol=1e-3, duals=false, query=false)
+    )
+end
+
 @testset "ModelLike tests" begin
     @test MOI.get(SOLVER, MOI.SolverName()) == "CPLEX"
     @testset "default_objective_test" begin

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -54,7 +54,7 @@ end
 @testset "Quadratic tests" begin
     MOIT.contquadratictest(
         SOLVER,
-        MOIT.TestConfig(atol=1e-3, rtol=1e-3, duals=false, query=false)
+        MOIT.TestConfig(atol=1e-3, rtol=1e-3, duals=true, query=true)
     )
 end
 


### PR DESCRIPTION
This PR addresses the issue #217, that is, add quadratic support in MOI_wrapper using LinQuadOptInterface.
It follows the recommendations of @odow see [discourse discussion about the subject](https://discourse.julialang.org/t/quadratic-programming-problem-cpl/21068).

I added two c_api functions to access primal and dual quadratic constraints values.
I added a get_qconstr function to get quadratic constraints through C api as well.

It adds the MOI contquadratic tests in the tests folder.
1 test fails in linear10. I do not think my changes are responsible.
4 tests fail in qcp1. I do not understand why yet as the following example does not reproduce the failures.

```julia
using JuMP, CPLEX

m = Model(with_optimizer(CPLEX.Optimizer))

@variable(m, x)
@variable(m, y)

A = [-1 1; 1 1]

c1 = @constraint(m, A*[x,y] .>= 0)
c2 = @constraint(m, x*x + y <= 2)

@objective(m, Max, x+y)

optimize!(m)

println(m)

println(value(x), " ", value(y), " ", objective_value(m))

model = m.moi_backend.optimizer.model

println(MOI.get(model, MOI.ObjectiveValue()))

println(MOI.get.(model, MOI.VariablePrimal(), [x.index,y.index]))

println(MOI.get.(model, MOI.ConstraintPrimal(), [c1[1].index c1[2].index]))

println(MOI.get(model, MOI.ConstraintPrimal(), c2.index))
```