### PR TITLE
Fix bug in sense of vector sets

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -77,9 +77,9 @@ LQOI.backend_type(model::Optimizer, ::MOI.EqualTo{Float64})     = Cchar('E')
 LQOI.backend_type(model::Optimizer, ::MOI.LessThan{Float64})    = Cchar('L')
 LQOI.backend_type(model::Optimizer, ::MOI.GreaterThan{Float64}) = Cchar('G')
 
-LQOI.backend_type(model::Optimizer, ::MOI.Zeros)                = Cchar('B')
+LQOI.backend_type(model::Optimizer, ::MOI.Zeros)                = Cchar('E')
 LQOI.backend_type(model::Optimizer, ::MOI.Nonpositives)         = Cchar('L')
-LQOI.backend_type(model::Optimizer, ::MOI.Nonnegatives)         = Cchar('E')
+LQOI.backend_type(model::Optimizer, ::MOI.Nonnegatives)         = Cchar('G')
 
 function LQOI.change_variable_bounds!(model::Optimizer,
         columns::Vector{Int}, values::Vector{Float64}, senses::Vector{Cchar})
@@ -169,6 +169,7 @@ function LQOI.change_objective_sense!(model::Optimizer, symbol)
     if symbol == :min
         c_api_chgobjsen(model.inner, Cint(1))
     else
+        @assert symbol == :max
         c_api_chgobjsen(model.inner, Cint(-1))
     end
     return
@@ -184,6 +185,7 @@ function LQOI.get_objectivesense(model::Optimizer)
     if s == 1
         return MOI.MIN_SENSE
     else
+        @assert s == -1
         return MOI.MAX_SENSE
     end
 end

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -25,7 +25,8 @@ end
 @testset "Linear tests" begin
     @testset "Default Solver"  begin
         MOIT.contlineartest(SOLVER, CONFIG, [
-            "linear10",  # Requires interval
+            # Requires interval
+            "linear10", "linear10b",
             # Requires infeasiblity certificates
             "linear8a", "linear8b", "linear8c", "linear11", "linear12",
             # VariablePrimalStart not implemented.
@@ -34,18 +35,21 @@ end
     end
     @testset "linear10" begin
         MOIT.linear10test(MOIB.SplitInterval{Float64}(SOLVER), CONFIG)
+        MOIT.linear10btest(MOIB.SplitInterval{Float64}(SOLVER), CONFIG)
     end
     @testset "No certificate" begin
         MOIT.linear12test(
-            SOLVER,
-            MOIT.TestConfig(infeas_certificates=false)
-        )
+            SOLVER, MOIT.TestConfig(infeas_certificates=false))
     end
 end
+
+@testset "Linear Conic" begin
+    # TODO(odow): why no infeasiblity certificates here?
+    MOIT.lintest(SOLVER, MOIT.TestConfig(infeas_certificates=false))
+end
+
 @testset "Integer Linear tests" begin
-    MOIT.intlineartest(SOLVER, CONFIG, [
-        "int3"  # Requires Interval
-    ])
+    MOIT.intlineartest(SOLVER, CONFIG, ["int3"])
     @testset "int3" begin
         MOIT.int3test(MOIB.SplitInterval{Float64}(SOLVER), CONFIG)
     end


### PR DESCRIPTION
Turns out that the `MOIT.lintest` wasn't included. That would have caught the typo.

![image](https://user-images.githubusercontent.com/8177701/56003096-c1500580-5c8a-11e9-82ad-e54343fe2413.png)
