### PR TITLE
Compute conflict/IIS

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -482,6 +482,9 @@ function compute_conflict(model::Optimizer)
         end
     end
     return
+
+    # TODO: decide what to do about the POSSIBLE statuses for the constraints (CPX_CONFLICT_POSSIBLE_MEMBER, 
+    # CPX_CONFLICT_POSSIBLE_UB, CPX_CONFLICT_POSSIBLE_LB). 
 end
 
 function _ensure_conflict_computed(model::Optimizer)

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -547,19 +547,9 @@ function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.Constr
         model.conflict.colstat[var_in_conflict] == CPLEX.CPX_CONFLICT_LB
 end
 
-function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, <:LQOI.LE})
+function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, <:Union{LQOI.LE, LQOI.GE, LQOI.EQ}})
     _ensure_conflict_computed(model)
-    return (LQOI.cmap(model).less_than[index] - 1) in model.conflict.rowind
-end
-
-function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, <:LQOI.GE})
-    _ensure_conflict_computed(model)
-    return (LQOI.cmap(model).greater_than[index] - 1) in model.conflict.rowind
-end
-
-function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, <:LQOI.EQ})
-    _ensure_conflict_computed(model)
-    return (LQOI.cmap(model).equal_to[index] - 1) in model.conflict.rowind
+    return (model[index] - 1) in model.conflict.rowind
 end
 
 function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.SingleVariable, <:Union{LQOI.LE, LQOI.GE}}})

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -490,7 +490,7 @@ If a minimal conflict is found, it will return `MOI.OPTIMAL`. If the problem is 
 return `MOI.INFEASIBLE`. If `compute_conflict` has not been called yet, it will return
 `MOI.OPTIMIZE_NOT_CALLED`.
 """
-struct ConflictStatus <: MOI.AbstractOptimizerAttribute  end
+struct ConflictStatus <: MOI.AbstractModelAttribute  end
 MOI.is_set_by_optimize(::ConflictStatus) = true
 
 function MOI.get(model::Optimizer, ::ConflictStatus)

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -539,17 +539,17 @@ end
 
 function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, <:LQOI.LE})
     _ensure_conflict_computed(model)
-    return LQOI.cmap(model).less_than[index] in model.conflict.rowind
+    return (LQOI.cmap(model).less_than[index] - 1) in model.conflict.rowind
 end
 
 function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, <:LQOI.GE})
     _ensure_conflict_computed(model)
-    return LQOI.cmap(model).greater_than[index] in model.conflict.rowind
+    return (LQOI.cmap(model).greater_than[index] - 1) in model.conflict.rowind
 end
 
 function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, <:LQOI.EQ})
     _ensure_conflict_computed(model)
-    return LQOI.cmap(model).equal_to[index] in model.conflict.rowind
+    return (LQOI.cmap(model).equal_to[index] - 1) in model.conflict.rowind
 end
 
 function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.SingleVariable, T}}) where {T <: LQOI.LinSets}
@@ -570,7 +570,7 @@ MOI.is_set_by_optimize(::VariableConflictStatus) = true
 
 function MOI.get(model::Optimizer, ::VariableConflictStatus, index::MOI.VariableIndex)
     _ensure_conflict_computed(model)
-    return LQOI.get_column(model, index) in model.conflict.colind
+    return (LQOI.get_column(model, index) - 1) in model.conflict.colind
 end
 
 function MOI.supports(::Optimizer, ::VariableConflictStatus, ::Type{<:MOI.VariableIndex})

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -457,7 +457,7 @@ function LQOI.make_problem_type_continuous(optimizer::Optimizer)
     return
 
 function compute_conflict(model::Optimizer)
-    model.conflict = refineconflict(model.inner)
+    model.conflict = c_api_getconflict(model.inner)
     return
 end
 

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -532,7 +532,7 @@ MOI.is_set_by_optimize(::ConstraintConflictStatus) = true
 
 function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex)
     _ensure_conflict_computed(model)
-    return index in model.conflict.rowind
+    return index.value in model.conflict.rowind
 end
 
 function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{<:MOI.ConstraintIndex})
@@ -549,7 +549,7 @@ MOI.is_set_by_optimize(::VariableConflictStatus) = true
 
 function MOI.get(model::Optimizer, ::VariableConflictStatus, index::MOI.VariableIndex)
     _ensure_conflict_computed(model)
-    return index in model.conflict.colind
+    return index.value in model.conflict.colind
 end
 
 function MOI.supports(::Optimizer, ::VariableConflictStatus, ::Type{<:MOI.VariableIndex})

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -564,10 +564,10 @@ function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.Constr
     return (model[index] - 1) in model.conflict.rowind
 end
 
-function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.SingleVariable, T}}) where {T <: LQOI.LinSets}
+function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.SingleVariable, <:LQOI.LinSets}})
     return true
 end
 
-function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, T}}) where {T <: LQOI.LinSets}
+function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, <:Union{LQOI.LE, LQOI.GE, LQOI.EQ}}})
     return true
 end

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -470,13 +470,15 @@ conflict is not purged, and any calls to the above attributes will return values
 for the original conflict without a warning.
 """
 function compute_conflict(model::Optimizer)
+    # In case there is no conflict, c_api_getconflict throws an error, while the conflict 
+    # data structure can handle more gracefully this case (via a status check). 
     try 
         model.conflict = c_api_getconflict(model.inner)
     catch exc
         if isa(exc, CplexError) && exc.code == CPXERR_NO_CONFLICT
             model.conflict = ConflictRefinerData(CPX_STAT_CONFLICT_FEASIBLE, 0, Cint[], Cint[], 0, Cint[], Cint[])
         else
-            throw(exc)
+            rethrow(exc)
         end
     end
     return

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -533,12 +533,22 @@ A Boolean constraint attribute indicating whether the constraint participates in
 struct ConstraintConflictStatus <: MOI.AbstractConstraintAttribute end
 MOI.is_set_by_optimize(::ConstraintConflictStatus) = true
 
-function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex)
+function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, <:LQOI.LE})
     _ensure_conflict_computed(model)
-    return LQOI.get_column(model, index) in model.conflict.rowind
+    return LQOI.cmap(model).less_than[index] in model.conflict.rowind
 end
 
-function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{<:MOI.ConstraintIndex})
+function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, <:LQOI.GE})
+    _ensure_conflict_computed(model)
+    return LQOI.cmap(model).greater_than[index] in model.conflict.rowind
+end
+
+function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, <:LQOI.EQ})
+    _ensure_conflict_computed(model)
+    return LQOI.cmap(model).equal_to[index] in model.conflict.rowind
+end
+
+function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, T}}) where {T <: LQOI.LinSets}
     return true
 end
 

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -533,6 +533,10 @@ A Boolean constraint attribute indicating whether the constraint participates in
 struct ConstraintConflictStatus <: MOI.AbstractConstraintAttribute end
 MOI.is_set_by_optimize(::ConstraintConflictStatus) = true
 
+function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.SingleVariable, <:LQOI.LinSets})
+    return MOI.get(model, CPLEX.VariableConflictStatus(), model[index])
+end
+
 function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, <:LQOI.LE})
     _ensure_conflict_computed(model)
     return LQOI.cmap(model).less_than[index] in model.conflict.rowind
@@ -546,6 +550,10 @@ end
 function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, <:LQOI.EQ})
     _ensure_conflict_computed(model)
     return LQOI.cmap(model).equal_to[index] in model.conflict.rowind
+end
+
+function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.SingleVariable, T}}) where {T <: LQOI.LinSets}
+    return true
 end
 
 function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, T}}) where {T <: LQOI.LinSets}

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -569,20 +569,3 @@ end
 function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, T}}) where {T <: LQOI.LinSets}
     return true
 end
-
-"""
-    VariableConflictStatus()
-
-A Boolean variable attribute indicating whether the variable participates in the last computed conflict.
-"""
-struct VariableConflictStatus <: MOI.AbstractVariableAttribute end
-MOI.is_set_by_optimize(::VariableConflictStatus) = true
-
-function MOI.get(model::Optimizer, ::VariableConflictStatus, index::MOI.VariableIndex)
-    _ensure_conflict_computed(model)
-    return (LQOI.get_column(model, index) - 1) in model.conflict.colind
-end
-
-function MOI.supports(::Optimizer, ::VariableConflictStatus, ::Type{<:MOI.VariableIndex})
-    return true
-end

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -470,7 +470,15 @@ conflict is not purged, and any calls to the above attributes will return values
 for the original conflict without a warning.
 """
 function compute_conflict(model::Optimizer)
-    model.conflict = c_api_getconflict(model.inner)
+    try 
+        model.conflict = c_api_getconflict(model.inner)
+    catch exc
+        if isa(exc, CplexError) && exc.code == CPXERR_NO_CONFLICT
+            model.conflict = ConflictRefinerData(CPX_STAT_CONFLICT_FEASIBLE, 0, Cint[], Cint[], 0, Cint[], Cint[])
+        else
+            throw(exc)
+        end
+    end
     return
 end
 

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -462,17 +462,16 @@ function LQOI.make_problem_type_continuous(optimizer::Optimizer)
 Compute a minimal subset of the constraints and variables that keep the model
 infeasible.
 
-See also `CPLEX.ConflictStatus`, `CPLEX.VariableConflictStatus`, and
-`CPLEX.ConstraintConflictStatus`.
+See also `CPLEX.ConflictStatus` and `CPLEX.ConstraintConflictStatus`.
 
 Note that if `model` is modified after a call to `compute_conflict`, the
 conflict is not purged, and any calls to the above attributes will return values
 for the original conflict without a warning.
 """
 function compute_conflict(model::Optimizer)
-    # In case there is no conflict, c_api_getconflict throws an error, while the conflict 
-    # data structure can handle more gracefully this case (via a status check). 
-    try 
+    # In case there is no conflict, c_api_getconflict throws an error, while the conflict
+    # data structure can handle more gracefully this case (via a status check).
+    try
         model.conflict = c_api_getconflict(model.inner)
     catch exc
         if isa(exc, CplexError) && exc.code == CPXERR_NO_CONFLICT
@@ -483,8 +482,8 @@ function compute_conflict(model::Optimizer)
     end
     return
 
-    # TODO: decide what to do about the POSSIBLE statuses for the constraints (CPX_CONFLICT_POSSIBLE_MEMBER, 
-    # CPX_CONFLICT_POSSIBLE_UB, CPX_CONFLICT_POSSIBLE_LB). 
+    # TODO: decide what to do about the POSSIBLE statuses for the constraints (CPX_CONFLICT_POSSIBLE_MEMBER,
+    # CPX_CONFLICT_POSSIBLE_UB, CPX_CONFLICT_POSSIBLE_LB).
 end
 
 function _ensure_conflict_computed(model::Optimizer)

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -554,7 +554,7 @@ function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.Constr
     return status !== nothing && (status == CPLEX.CPX_CONFLICT_MEMBER || status == CPLEX.CPX_CONFLICT_LB)
 end
 
-function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.SingleVariable, <:LQOI.EQ})
+function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.SingleVariable, <:Union{LQOI.EQ, LQOI.IV}})
     status = _sinvar_get_conflict_status(model, index)
     return status !== nothing && (status == CPLEX.CPX_CONFLICT_MEMBER || status == CPLEX.CPX_CONFLICT_LB || status == CPLEX.CPX_CONFLICT_UB)
 end
@@ -564,7 +564,7 @@ function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.Constr
     return (model[index] - 1) in model.conflict.rowind
 end
 
-function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.SingleVariable, <:Union{LQOI.LE, LQOI.GE, LQOI.EQ}}})
+function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.SingleVariable, T}}) where {T <: LQOI.LinSets}
     return true
 end
 

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -469,7 +469,7 @@ An optimizer attribute indicating the status of the last computed conflict.
 struct ConflictStatus <: MOI.AbstractOptimizerAttribute  end
 MOI.is_set_by_optimize(::ConflictStatus) = true
 
-function MOI.get(model::Optimizer, attribute::ConflictStatus)
+function MOI.get(model::Optimizer, ::ConflictStatus)
     if model.conflict == nothing
         return MOI.OPTIMIZE_NOT_CALLED
     elseif model.conflict.stat == CPX_STAT_CONFLICT_MINIMAL
@@ -492,6 +492,8 @@ function MOI.get(model::Optimizer, attribute::ConflictStatus)
         return MOI.TIME_LIMIT
     elseif model.conflict.stat == CPX_STAT_CONFLICT_ABORT_USER
         return MOI.OTHER_LIMIT
+    else
+        return MOI.OTHER_LIMIT
     end
 end
 
@@ -502,13 +504,13 @@ end
 """
     ConstraintConflictStatus()
 
-A constraint attribute indicating whether the constraint participates in the last computed conflict.
+A Boolean constraint attribute indicating whether the constraint participates in the last computed conflict.
 """
 struct ConstraintConflictStatus <: MOI.AbstractConstraintAttribute end
 MOI.is_set_by_optimize(::ConstraintConflictStatus) = true
 
-function MOI.get(model::Optimizer, attribute::ConstraintConflictStatus, index::MOI.ConstraintIndex)
-    return in(index, model.conflict.rowind)
+function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex)
+    return index in model.conflict.rowind
 end
 
 function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{<:MOI.ConstraintIndex})
@@ -518,12 +520,12 @@ end
 """
     VariableConflictStatus()
 
-A variable attribute indicating whether the variable participates in the last computed conflict.
+A Boolean variable attribute indicating whether the variable participates in the last computed conflict.
 """
 struct VariableConflictStatus <: MOI.AbstractVariableAttribute end
 MOI.is_set_by_optimize(::VariableConflictStatus) = true
 
-function MOI.get(model::Optimizer, attribute::VariableConflictStatus, index::MOI.VariableIndex)
+function MOI.get(model::Optimizer, ::VariableConflictStatus, index::MOI.VariableIndex)
     return in(index, model.conflict.colind)
 end
 

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -562,11 +562,7 @@ function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.Constr
     return (LQOI.cmap(model).equal_to[index] - 1) in model.conflict.rowind
 end
 
-function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.SingleVariable, LQOI.LE}})
-    return true
-end
-
-function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.SingleVariable, LQOI.GE}})
+function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.SingleVariable, <:Union{LQOI.LE, LQOI.GE}}})
     return true
 end
 

--- a/src/cpx_model.jl
+++ b/src/cpx_model.jl
@@ -263,10 +263,10 @@ function c_api_getconflict(model::Model)
     confnumrows_p = Ref{Cint}()
     confnumcols_p = Ref{Cint}()
     stat = @cpx_ccall(
-                refineconflict, 
-                Cint, 
-                (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}, Ptr{Cint}),
-                model.env.ptr, model.lp, confnumrows_p, confnumcols_p)
+        refineconflict, 
+        Cint, 
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}, Ptr{Cint}),
+        model.env.ptr, model.lp, confnumrows_p, confnumcols_p)
     if stat != 0
         throw(CplexError(model.env, stat))
     end
@@ -280,10 +280,10 @@ function c_api_getconflict(model::Model)
     colbdstat = Vector{Cint}(undef, confnumcols_p[])
     confnumcols_p  = Ref{Cint}()
     stat = @cpx_ccall(
-                getconflict, 
-                Cint, 
-                (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
-                model.env.ptr, model.lp, confstat_p, rowind, rowbdstat, confnumrows_p, colind, colbdstat, confnumcols_p)
+        getconflict, 
+        Cint, 
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+        model.env.ptr, model.lp, confstat_p, rowind, rowbdstat, confnumrows_p, colind, colbdstat, confnumcols_p)
     if stat != 0
         throw(CplexError(model.env, stat))
     end

--- a/src/cpx_model.jl
+++ b/src/cpx_model.jl
@@ -260,8 +260,8 @@ function c_api_getconflict(model::Model)
     # In other words, any call to this function is expensive. 
 
     # First, compute the conflict. 
-    confnumrows_p = Vector{Cint}(undef, 1)
-    confnumcols_p = Vector{Cint}(undef, 1)
+    confnumrows_p = Ref{Cint}()
+    confnumcols_p = Ref{Cint}()
     stat = @cpx_ccall(
                 refineconflict, 
                 Cint, 
@@ -273,11 +273,11 @@ function c_api_getconflict(model::Model)
 
     # Then, retrieve it. 
     confstat_p = Ref{Cint}()
-    rowind = Vector{Cint}(undef, confnumrows_p[1])
-    rowbdstat = Vector{Cint}(undef, confnumrows_p[1])
+    rowind = Vector{Cint}(undef, confnumrows_p[])
+    rowbdstat = Vector{Cint}(undef, confnumrows_p[])
     confnumrows_p = Ref{Cint}()
-    colind = Vector{Cint}(undef, confnumcols_p[1])
-    colbdstat = Vector{Cint}(undef, confnumcols_p[1])
+    colind = Vector{Cint}(undef, confnumcols_p[])
+    colbdstat = Vector{Cint}(undef, confnumcols_p[])
     confnumcols_p  = Ref{Cint}()
     stat = @cpx_ccall(
                 getconflict, 

--- a/test/C_API/iis.jl
+++ b/test/C_API/iis.jl
@@ -11,9 +11,6 @@
 @testset "IIS" begin
     env = CPLEX.Env()
 
-    # method = getparam(env, "Method")
-    # println("method = $method")
-
     model = CPLEX.Model(env, "iis")
     CPLEX.set_sense!(model, :Max)
 

--- a/test/C_API/iis.jl
+++ b/test/C_API/iis.jl
@@ -1,0 +1,38 @@
+# a simple LP example
+#
+#   maximize x 
+#
+#   s.t. x >= 2
+#        x <= 1
+#        x >= 0
+#
+#   conflict: the two constraints
+
+@testset "IIS" begin
+    env = CPLEX.Env()
+
+    # method = getparam(env, "Method")
+    # println("method = $method")
+
+    model = CPLEX.Model(env, "iis")
+    CPLEX.set_sense!(model, :Max)
+
+    # add variables
+    CPLEX.add_var!(model, 1.0, 0., Inf)  # x
+
+    # add constraints
+    CPLEX.add_constr!(model, [1.], '>', 2.)
+    CPLEX.add_constr!(model, [1.], '<', 1.)
+
+    # compute conflict
+    c = CPLEX.c_api_getconflict(model)
+
+    @test c !== nothing
+    @test c.stat == CPLEX.CPX_STAT_CONFLICT_MINIMAL
+    @test c.nrows == 2
+    @test c.rowind[1] == 0
+    @test c.rowind[2] == 1
+    @test c.ncols == 0
+
+    # gc()  # test finalizers
+end

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -177,18 +177,15 @@ end
         # Test similar to ../C_API/iis.jl, but ported to MOI.
         model = CPLEX.Optimizer()
         x = MOI.add_variable(model)
-        b = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
         c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(2.0))
         c2 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan(1.0))
 
         # Getting the results before the conflict refiner has been called must return an error.
         @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
-        @test_throws ErrorException MOI.get(model, CPLEX.VariableConflictStatus(), x)
         @test_throws ErrorException MOI.get(model, CPLEX.ConstraintConflictStatus(), c1)
 
         # Once it's called, no problem.
         CPLEX.compute_conflict(model)
-        @test MOI.get(model, CPLEX.VariableConflictStatus(), x) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == true
     end
@@ -197,9 +194,8 @@ end
         # Same test as ../C_API/iis.jl, but ported to MOI.
         model = CPLEX.Optimizer()
         x = MOI.add_variable(model)
-        b = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
-        c1 = MOI.add_constraint(model, MOI.ScalarAffineTerm.([1.0], [x], 0.0), MOI.GreaterThan(2.0))
-        c2 = MOI.add_constraint(model, MOI.ScalarAffineTerm.([1.0], [x], 0.0), MOI.LessThan(1.0))
+        c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.GreaterThan(2.0))
+        c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.LessThan(1.0))
 
         # Getting the results before the conflict refiner has been called must return an error.
         @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
@@ -216,7 +212,7 @@ end
         x = MOI.add_variable(model)
         y = MOI.add_variable(model)
         b1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
-        b2 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+        b2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
         cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0)
         c1 = MOI.add_constraint(model, cf1, MOI.LessThan(-1.0))
         cf2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], [x, y]), 0.0)
@@ -228,7 +224,9 @@ end
 
         # Once it's called, no problem.
         CPLEX.compute_conflict(model)
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), b1) == true
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), b2) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
-        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == true
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == false
     end
 end

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -173,21 +173,23 @@ end
 end
 
 @testset "Conflict refiner" begin
-    # Same test as ../C_API/iis.jl, but ported to MOI.
-    model = CPLEX.Optimizer()
-    x = MOI.add_variable(model)
-    b = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
-    c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(2.0))
-    c2 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan(1.0))
+    @testset "Variable bounds" begin
+        # Same test as ../C_API/iis.jl, but ported to MOI.
+        model = CPLEX.Optimizer()
+        x = MOI.add_variable(model)
+        b = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+        c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(2.0))
+        c2 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan(1.0))
 
-    # Getting the results before the conflict refiner has been called must return an error.
-    @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
-    @test_throws ErrorException MOI.get(model, CPLEX.VariableConflictStatus(), x)
-    @test_throws ErrorException MOI.get(model, CPLEX.ConstraintConflictStatus(), c1)
+        # Getting the results before the conflict refiner has been called must return an error.
+        @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
+        @test_throws ErrorException MOI.get(model, CPLEX.VariableConflictStatus(), x)
+        @test_throws ErrorException MOI.get(model, CPLEX.ConstraintConflictStatus(), c1)
 
-    # Once it's called, no problem.
-    CPLEX.compute_conflict(model)
-    @test MOI.get(model, CPLEX.VariableConflictStatus(), x) == false
-    @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
-    @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == true
+        # Once it's called, no problem.
+        CPLEX.compute_conflict(model)
+        @test MOI.get(model, CPLEX.VariableConflictStatus(), x) == true
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == true
+    end
 end

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -173,7 +173,7 @@ end
 end
 
 @testset "Conflict refiner" begin
-    @testset "Variable bounds (SingleVariable)" begin
+    @testset "Variable bounds (SingleVariable and LessThan/GreaterThan)" begin
         # Test similar to ../C_API/iis.jl, but ported to MOI.
         model = CPLEX.Optimizer()
         x = MOI.add_variable(model)
@@ -207,6 +207,24 @@ end
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == true
     end
 
+    @testset "Variable fixing (SingleVariable and EqualTo)" begin
+        model = CPLEX.Optimizer()
+        x = MOI.add_variable(model)
+        c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.EqualTo(1.0))
+        c2 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan(1.0))
+        c3 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(2.0))
+
+        # Getting the results before the conflict refiner has been called must return an error.
+        @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
+        @test_throws ErrorException MOI.get(model, CPLEX.ConstraintConflictStatus(), c1)
+
+        # Once it's called, no problem.
+        CPLEX.compute_conflict(model)
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == true
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c3) == true
+    end
+
     @testset "Two conflicting constraints" begin
         model = CPLEX.Optimizer()
         x = MOI.add_variable(model)
@@ -226,6 +244,32 @@ end
         CPLEX.compute_conflict(model)
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), b1) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), b2) == true
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == false
+    end
+
+    @testset "Variables outside conflict" begin
+        model = CPLEX.Optimizer()
+        x = MOI.add_variable(model)
+        y = MOI.add_variable(model)
+        z = MOI.add_variable(model)
+        b1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+        b2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+        b3 = MOI.add_constraint(model, MOI.SingleVariable(z), MOI.GreaterThan(0.0))
+        cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0)
+        c1 = MOI.add_constraint(model, cf1, MOI.LessThan(-1.0))
+        cf2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0, 1.0], [x, y, z]), 0.0)
+        c2 = MOI.add_constraint(model, cf2, MOI.GreaterThan(1.0))
+
+        # Getting the results before the conflict refiner has been called must return an error.
+        @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
+        @test_throws ErrorException MOI.get(model, CPLEX.ConstraintConflictStatus(), c1)
+
+        # Once it's called, no problem.
+        CPLEX.compute_conflict(model)
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), b1) == true
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), b2) == true
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), b3) == false
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == false
     end

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -203,12 +203,10 @@ end
 
         # Getting the results before the conflict refiner has been called must return an error.
         @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
-        @test_throws ErrorException MOI.get(model, CPLEX.VariableConflictStatus(), x)
         @test_throws ErrorException MOI.get(model, CPLEX.ConstraintConflictStatus(), c1)
 
         # Once it's called, no problem.
         CPLEX.compute_conflict(model)
-        @test MOI.get(model, CPLEX.VariableConflictStatus(), x) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == true
     end
@@ -226,13 +224,10 @@ end
 
         # Getting the results before the conflict refiner has been called must return an error.
         @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
-        @test_throws ErrorException MOI.get(model, CPLEX.VariableConflictStatus(), x)
         @test_throws ErrorException MOI.get(model, CPLEX.ConstraintConflictStatus(), c1)
 
         # Once it's called, no problem.
         CPLEX.compute_conflict(model)
-        @test MOI.get(model, CPLEX.VariableConflictStatus(), x) == true
-        @test MOI.get(model, CPLEX.VariableConflictStatus(), y) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == true
     end

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -186,6 +186,7 @@ end
 
         # Once it's called, no problem.
         CPLEX.compute_conflict(model)
+        @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMAL
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == true
     end
@@ -203,6 +204,7 @@ end
 
         # Once it's called, no problem.
         CPLEX.compute_conflict(model)
+        @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMAL
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == true
     end
@@ -219,6 +221,7 @@ end
 
         # Once it's called, no problem. 
         CPLEX.compute_conflict(model)
+        @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMAL
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == true
     end
@@ -235,6 +238,7 @@ end
 
         # Once it's called, no problem.
         CPLEX.compute_conflict(model)
+        @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMAL
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == true
     end
@@ -256,6 +260,7 @@ end
 
         # Once it's called, no problem.
         CPLEX.compute_conflict(model)
+        @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMAL
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), b1) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), b2) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
@@ -279,6 +284,7 @@ end
 
         # Once it's called, no problem. 
         CPLEX.compute_conflict(model)
+        @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMAL
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), b1) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), b2) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
@@ -304,10 +310,28 @@ end
 
         # Once it's called, no problem.
         CPLEX.compute_conflict(model)
+        @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMAL
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), b1) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), b2) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), b3) == false
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == false
+    end
+
+    @testset "No conflict" begin
+        model = CPLEX.Optimizer()
+        x = MOI.add_variable(model)
+        c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.GreaterThan(1.0))
+        c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.LessThan(2.0))
+
+        # Getting the results before the conflict refiner has been called must return an error. 
+        @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
+        @test_throws ErrorException MOI.get(model, CPLEX.ConstraintConflictStatus(), c1)
+
+        # Once it's called, no problem. 
+        CPLEX.compute_conflict(model)
+        @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.INFEASIBLE
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == false
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == false
     end
 end

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -187,7 +187,7 @@ end
 
     # Once it's called, no problem.
     CPLEX.compute_conflict(model)
-    @test !MOI.get(model, CPLEX.VariableConflictStatus(), x)
-    @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1)
-    @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2)
+    @test MOI.get(model, CPLEX.VariableConflictStatus(), x) == false
+    @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
+    @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == true
 end

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -239,7 +239,7 @@ end
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == true
     end
 
-    @testset "Two conflicting constraints" begin
+    @testset "Two conflicting constraints (GreaterThan, LessThan)" begin
         model = CPLEX.Optimizer()
         x = MOI.add_variable(model)
         y = MOI.add_variable(model)
@@ -255,6 +255,29 @@ end
         @test_throws ErrorException MOI.get(model, CPLEX.ConstraintConflictStatus(), c1)
 
         # Once it's called, no problem.
+        CPLEX.compute_conflict(model)
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), b1) == true
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), b2) == true
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == false
+    end
+
+    @testset "Two conflicting constraints (EqualTo)" begin
+        model = CPLEX.Optimizer()
+        x = MOI.add_variable(model)
+        y = MOI.add_variable(model)
+        b1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+        b2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+        cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0)
+        c1 = MOI.add_constraint(model, cf1, MOI.EqualTo(-1.0))
+        cf2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], [x, y]), 0.0)
+        c2 = MOI.add_constraint(model, cf2, MOI.GreaterThan(1.0))
+
+        # Getting the results before the conflict refiner has been called must return an error. 
+        @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
+        @test_throws ErrorException MOI.get(model, CPLEX.ConstraintConflictStatus(), c1)
+
+        # Once it's called, no problem. 
         CPLEX.compute_conflict(model)
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), b1) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), b2) == true

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -171,3 +171,23 @@ end
     MOI.optimize!(model)
     @test MOI.get(model, MOI.ObjectiveValue()) ≈ -1.5 atol=atol rtol=rtol
 end
+
+@testset "Conflict refiner" begin
+    # Same test as ../C_API/iis.jl, but ported to MOI.
+    model = CPLEX.Optimizer()
+    x = MOI.add_variable(model)
+    b = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(2.0))
+    c2 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan(1.0))
+
+    # Getting the results before the conflict refiner has been called must return an error.
+    @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
+    @test_throws ErrorException MOI.get(model, CPLEX.VariableConflictStatus(), x)
+    @test_throws ErrorException MOI.get(model, CPLEX.ConstraintConflictStatus(), c1)
+
+    # Once it's called, no problem.
+    CPLEX.compute_conflict(model)
+    @test !MOI.get(model, CPLEX.VariableConflictStatus(), x)
+    @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1)
+    @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2)
+end

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -211,8 +211,23 @@ end
         model = CPLEX.Optimizer()
         x = MOI.add_variable(model)
         c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.EqualTo(1.0))
-        c2 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan(1.0))
-        c3 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(2.0))
+        c2 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(2.0))
+
+        # Getting the results before the conflict refiner has been called must return an error. 
+        @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
+        @test_throws ErrorException MOI.get(model, CPLEX.ConstraintConflictStatus(), c1)
+
+        # Once it's called, no problem. 
+        CPLEX.compute_conflict(model)
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
+        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == true
+    end
+
+    @testset "Variable bounds (SingleVariable and Interval)" begin
+        model = CPLEX.Optimizer()
+        x = MOI.add_variable(model)
+        c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.Interval(1.0, 3.0))
+        c2 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan(0.0))
 
         # Getting the results before the conflict refiner has been called must return an error.
         @test MOI.get(model, CPLEX.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
@@ -222,7 +237,6 @@ end
         CPLEX.compute_conflict(model)
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c1) == true
         @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c2) == true
-        @test MOI.get(model, CPLEX.ConstraintConflictStatus(), c3) == true
     end
 
     @testset "Two conflicting constraints" begin


### PR DESCRIPTION
First step for https://github.com/JuliaOpt/JuMP.jl/issues/1035: implement the IIS/conflict within the CPLEX package. 

For now, quite basic: call the conflict refiner, store the information it returns in a structure (allocated only when needed, so that the overhead for people not using it is just one pointer per model).

Next, I will implement MOI attributes that call these functions (if the `conflict` member of `Model` is `nothing`, call the conflict refiner and retrieve its result; if the member is already available, just return the data from it). One question I have for now: I guess the model object may be reused; what happens when it is updated (for instance, the first model is infeasible; the user removes the culprit constraint, then resolves; say they call the conflict refiner again, how is the model reset?).