### PR TITLE
add function to switch cplex prob type

### DIFF
--- a/src/MOIWrapper.jl
+++ b/src/MOIWrapper.jl
@@ -180,12 +180,15 @@ function LQOI.delete_variables!(model::Optimizer,
 end
 
 function LQOI.solve_mip_problem!(model::Optimizer)
-    model.inner.has_int = true
-    LQOI.solve_linear_problem!(model)
+    LQOI.make_problem_type_integer(model)
+    optimize!(model.inner)
+    return
 end
 
-function LQOI.solve_linear_problem!(model::Optimizer)  
+function LQOI.solve_linear_problem!(model::Optimizer)
+    LQOI.make_problem_type_continuous(model)
     optimize!(model.inner)
+    return
 end
 
 function LQOI.get_termination_status(model::Optimizer)
@@ -267,4 +270,16 @@ end
 
 function LQOI.get_objective_value(model::Optimizer)
     return c_api_getobjval(model.inner)
+end
+
+function LQOI.make_problem_type_integer(optimizer::Optimizer)
+    optimizer.inner.has_int = true
+    set_prob_type!(optimizer.inner, :MILP)
+    return
+end
+
+function LQOI.make_problem_type_continuous(optimizer::Optimizer)
+    optimizer.inner.has_int = false
+    set_prob_type!(optimizer.inner, :LP)
+    return
 end


### PR DESCRIPTION
Related to this issue: https://github.com/atoptima/Coluna.jl/issues/56

I tried to use CPLEX as LP/MILP solver in Coluna as follows:
Use it as LP solver during the column generation iterations so solve the master LP and then at the end of the node switch to MILP to solve the IP version of the restricted master.

In order to change from one to the other I remove/ add all single variable integrality constraints.

What happens is that when I start to solve the second node (after removing all the integrality constraints), CPLEX is still in MILP mode, so I cannot get my dual values needed for the column generation.

I went to the code and saw that the function that changes the Cplex problem type (called if you just removed all integrality constraint or added one integrality constraint) was not implemented. There was a 'dirty fix' in place.
So I implemented in both senses (MILP -> LP and LP->MILP) and it worked just fine.