### PR TITLE
Remove note about use of CPLEX shared libraries not being supported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ official support for CPLEX in Julia, let them know!.*
 Setting up CPLEX on OS X and Linux
 ----------------------------------
 
-NOTE: CPLEX [does not officially support linking to their dynamic C library](https://www.ibm.com/developerworks/community/forums/html/topic?id=ca96447c-fe2d-4e8a-900e-cfe358a9bcec&ps=25), which is necessary for use from Julia. However, the steps outlined below have worked for OS-X, Windows, and Linux machines.
-
 1. First, you must obtain a copy of the CPLEX software and a license; trial versions and academic licenses are available [here](https://www.ibm.com/products/ilog-cplex-optimization-studio/pricing).
 
 2. Once CPLEX is installed on your machine, point the `LD_LIBRARY_PATH` variable to the directory containing the CPLEX library by adding, for example, ``export LD_LIBRARY_PATH="/path/to/cplex/bin/x86-64_linux":$LD_LIBRARY_PATH`` to your start-up file (e.g. ``.bash_profile``, [adding library path on Ubuntu](http://stackoverflow.com/questions/13428910/how-to-set-the-environmental-variable-ld-library-path-in-linux for a)). On linux, make sure this directory contains ``libcplexXXX.so`` where ``XXX`` is stands for the version number; on OS-X the file should be named ``libcplexXXX.dylib``. Alternatively, you can also use the `CPLEX_STUDIO_BINARIES` environment variable as follows:


### PR DESCRIPTION
As of CPLEX version 12.9 the use of the CPLEX shared libraries is
explicitly supported on all platforms. See the release note at
https://www.ibm.com/support/knowledgecenter/SSSA5P_12.9.0/ilog.odms.studio.help/CPLEX/ReleaseNotes/topics/releasenotes1290/newLinkingNonWindows.html
and the instructions at
https://www.ibm.com/support/knowledgecenter/SSSA5P_12.9.0/ilog.odms.studio.help/CPLEX/ReleaseNotes/topics/releasenotes1290/PLUGINS_ROOT/ilog.odms.cplex.help/CPLEX/UsrMan/topics/APIs/C/link_non_win_intro.html