### PR TITLE
Test CPLEX on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ branches:
   - "/^release-.*$/"
 env:
   global:
-    secure: DlLHJfhnRTodFqT1vbxkX5qwaSPKX5geq09kewkmk4TE1COFMeJXfH2KzpXCpKy0BREYuk5ZCDp5zNsYspNKzRt3Libl9Utz948NKcYSDgKRPAfvqs8Y5R57/TQvcvq6Y5UYPQ4USnktfEuXLCmJeGrnp1WtXUpvD5h6RjHgeKk=
+    secure: DaNdXjGimdqgZKNU7tarR2EHw9q6AEkO9aGW0SzUI3nWdWdcdssGL/GDGVVzz8zESqdJ4n7V8PqImyi5UNPKtcZpLFMRiOfWrq8S4uhhIdUs9t8R5k6bf76xtTiVb5xVNzq9cPwe3ktcV6odmLnu6I/kY/VYwOPU9mhVtaWBmT8=

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,3 @@ branches:
   only:
   - master
   - "/^release-.*$/"
-env:
-  global:
-    secure: DaNdXjGimdqgZKNU7tarR2EHw9q6AEkO9aGW0SzUI3nWdWdcdssGL/GDGVVzz8zESqdJ4n7V8PqImyi5UNPKtcZpLFMRiOfWrq8S4uhhIdUs9t8R5k6bf76xtTiVb5xVNzq9cPwe3ktcV6odmLnu6I/kY/VYwOPU9mhVtaWBmT8=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: julia
+codecov: true
+os:
+- linux
+julia:
+- 1.0
+- 1.1
+notifications:
+  email: false
+branches:
+  only:
+  - master
+  - "/^release-.*$/"
+env:
+  global:
+    secure: DlLHJfhnRTodFqT1vbxkX5qwaSPKX5geq09kewkmk4TE1COFMeJXfH2KzpXCpKy0BREYuk5ZCDp5zNsYspNKzRt3Libl9Utz948NKcYSDgKRPAfvqs8Y5R57/TQvcvq6Y5UYPQ4USnktfEuXLCmJeGrnp1WtXUpvD5h6RjHgeKk=

--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,11 @@ repo = "https://github.com/JuliaOpt/CPLEX.jl"
 version = "0.5.1"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinQuadOptInterface = "f8899e07-120b-5979-ab1d-7b97bb9e1a48"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 MathProgBase = "fdba3010-5040-5b88-9595-932c9decdf73"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -77,7 +77,7 @@ function try_travis_installation()
     write_depsfile(local_filename)
 end
 
-if get(ENV, "TRAVIS", false)
+if get(ENV, "TRAVIS", "false") == "true"
     try_travis_installation()
 else
     try_local_installation()

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,74 +1,84 @@
 using Libdl
 
-depsfile = joinpath(dirname(@__FILE__), "deps.jl")
+const depsfile = joinpath(dirname(@__FILE__), "deps.jl")
 if isfile(depsfile)
     rm(depsfile)
 end
 
 function write_depsfile(path)
     open(depsfile, "w") do f
-        print(f, "const libcplex = ")
-        show(f, path) # print with backslashes excaped on windows
-        println(f)
+        println(f, "const libcplex = \"$(escape_string(path))\"")
     end
+end
+
+function library_name(v)
+    cpx_prefix = Sys.iswindows() ? "" : "lib"
+    return "$(cpx_prefix)cplex$(v).$(Libdl.dlext)"
 end
 
 @static if Sys.isapple()
     Libdl.dlopen("libstdc++", Libdl.RTLD_GLOBAL)
 end
 
-base_cpxvers = ["128", "129"]
-cpxvers = [base_cpxvers; base_cpxvers .* "0"]
-base_env = "CPLEX_STUDIO_BINARIES"
-
-# Find the path to the CPLEX executable.
-cplex_path = try
-    @static if Sys.isapple() || Sys.isunix()
-        read(`which cplex`, String)
-    elseif Sys.iswindows()
-        read(`where cplex`, String)
-    end
-catch
-    nothing
-end
-if cplex_path !== nothing
-    # Extract the path to the folder containing the CPLEX executable.
-    cplex_path = dirname(strip(cplex_path))
-end
-
-# Iterate through a series of places where CPLEX could be found: either in the path (directly the callable library or
-# the CPLEX executable) or from an environment variable.
-cpx_prefix = Sys.iswindows() ? "" : "lib"
-
-libnames = String["cplex"]
-for v in reverse(cpxvers)
-    push!(libnames, "$(cpx_prefix)cplex$(v).$(Libdl.dlext)")
-    if cplex_path !== nothing
-        push!(libnames, joinpath(cplex_path, "$(cpx_prefix)cplex$(v).$(Libdl.dlext)"))
+function try_local_installation()
+    # Find the path to the CPLEX executable.
+    cplex_path = try
+        @static if Sys.isapple() || Sys.isunix()
+            dirname(strip(read(`which cplex`, String)))
+        elseif Sys.iswindows()
+            dirname(strip(read(`where cplex`, String)))
+        end
+    catch
+        nothing
     end
 
-    for env in [base_env, base_env * v]
-        if haskey(ENV, env)
+    # Iterate through a series of places where CPLEX could be found: either in
+    # the path (directly the callable library or # the CPLEX executable) or from
+    # an environment variable.
+    cpxvers = [
+        "128", "1280", "129", "1290"
+    ]
+    base_env = "CPLEX_STUDIO_BINARIES"
+
+    libnames = String["cplex"]
+    for v in reverse(cpxvers)
+        name = library_name(v)
+        push!(libnames, name)
+        if cplex_path !== nothing
+            push!(libnames, joinpath(cplex_path, name))
+        end
+        for env in [base_env, base_env * v]
+            !haskey(ENV, env) && continue
             for d in split(ENV[env], ';')
-                occursin("cplex", d) || continue
-                push!(libnames, joinpath(d, "$(cpx_prefix)cplex$(v).$(Libdl.dlext)"))
+                !occursin("cplex", d) && continue
+                push!(libnames, joinpath(d, name))
             end
         end
     end
-end
 
-# Perform the actual search in the potential places.
-found = false
-for l in libnames
-    d = Libdl.dlopen_e(l)
-    if d != C_NULL
-        global found = true
+    # Perform the actual search in the potential places.
+    for l in libnames
+        d = Libdl.dlopen_e(l)
+        d == C_NULL && continue
         write_depsfile(Libdl.dlpath(d))
-        @info("Using CPLEX found in location `$(libname)`")
-        break
+        @info("Using CPLEX found in location `$(l)`")
+        return
     end
+    error(
+        "Unable to locate CPLEX installation. Note this must be downloaded " *
+        "separately. See the CPLEX.jl README for further instructions."
+    )
 end
 
-if !found
-    error("Unable to locate CPLEX installation. Note this must be downloaded separately. See the CPLEX.jl README for further instructions.")
+function try_travis_installation()
+    url = ENV["SECRET_CPLEX_URL"]
+    local_filename = joinpath(@__DIR__, "libcplex.so")
+    download(url, local_filename)
+    write_depsfile(local_filename)
+end
+
+if get(ENV, "TRAVIS", false)
+    try_travis_installation()
+else
+    try_local_installation()
 end


### PR DESCRIPTION
I'm embarking on a CPLEX.jl re-write.

Step 1: get CPLEX running on Travis
Step 2: write the MOI wrapper
Step 3: replace the existing C wrapper with one generated by Clang.jl
Step 4: change MOI wrapper as needed to account for the Clang wrapper.

The `libcplex.so` is currently stored in a public storage provider accessible with the correct URL, which is stored in a secured environment variable:
https://docs.travis-ci.com/user/environment-variables#defining-variables-in-repository-settings

By default, Pull Requests that come from a fork of this repo can't access the `SECRET_URL_KEY` so they will fail: https://docs.travis-ci.com/user/pull-requests#pull-requests-and-security-restrictions

Thus, only JuliaOpt members with commit access can trigger builds using the CPLEX binary. This isn't a good long-term solution, but it can be ameliorated by us distributing the community edition, and using that on Travis.

cc @mlubin 