### PR TITLE
Fix install and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-CPLEX.jl
-========
+# CPLEX.jl
 
 `CPLEX.jl` is an interface to the [IBM® ILOG® CPLEX® Optimization
 Studio](https://www.ibm.com/products/ilog-cplex-optimization-studio). It
@@ -21,70 +20,44 @@ CPLEX license to test `CPLEX.jl` on Travis. If you are a commercial customer
 interested in official support for CPLEX in Julia, let them know!.*
 
 
-Setting up CPLEX on OS X and Linux
-----------------------------------
+## Installation
 
-1. First, you must obtain a copy of the CPLEX software and a license; trial versions and academic licenses are available [here](https://www.ibm.com/products/ilog-cplex-optimization-studio/pricing).
+First, you must obtain a copy of the CPLEX software and a license. Then, set the
+appropriate environment vairable and run `Pkg.add("CPLEX")`.
 
-2. Once CPLEX is installed on your machine, point the `LD_LIBRARY_PATH` variable to the directory containing the CPLEX library by adding, for example, ``export LD_LIBRARY_PATH="/path/to/cplex/bin/x86-64_linux":$LD_LIBRARY_PATH`` to your start-up file (e.g. ``.bash_profile``, [adding library path on Ubuntu](http://stackoverflow.com/questions/13428910/how-to-set-the-environmental-variable-ld-library-path-in-linux for a)). On linux, make sure this directory contains ``libcplexXXX.so`` where ``XXX`` is stands for the version number; on OS-X the file should be named ``libcplexXXX.dylib``. Alternatively, you can also use the `CPLEX_STUDIO_BINARIES` environment variable as follows:
-  ```
-  $ CPLEX_STUDIO_BINARIES=/path/to/cplex/bin/x86-64_linux julia -e 'import Pkg; Pkg.add("CPLEX"); Pkg.build("CPLEX")'
-  ```
-
-3. At the Julia prompt, run
-  ```
-  julia> Pkg.add("CPLEX")
-  ```
-(or manually clone this module to your ``.julia`` directory).
-
-4. Check that your version is included in ``deps/build.jl`` in the aliases for the library dependency; if not, open an issue.
-
-Note for windows
-----------------
-
-Currently, CPLEX.jl is compatible only with 64-bit CPLEX and 64-bit Julia on Windows. CPLEX.jl attempts to automatically find the CPLEX library based on the `CPLEX_STUDIO_BINARIESXXX` environmental variable set by the CPLEX installer where `XXX` is the CPLEX version. For example:
 ```julia
-julia> ENV["CPLEX_STUDIO_BINARIES128"] = "C:/IBM/CPLEX_Studio128/cplex/bin/x64_win64"
+# Linux
+ENV["CPLEX_STUDIO_BINARIES"] = "/path/to/cplex/bin/x86-64_linux"
 
-julia> Pkg.build("CPLEX")
+# OSX
+ENV["CPLEX_STUDIO_BINARIES"] = "/path/to/cplex/bin/x86-64_osx"
+
+# Windows
+ENV["CPLEX_STUDIO_BINARIES"] = "C:/IBM/CPLEX_Studio128/cplex/bin/x64_win64"
+
+import Pkg
+Pkg.add("CPLEX")
 ```
 
-Help! I got `LoadError: Unable to locate CPLEX installation`
-----------------------------------
+## Help! I got `LoadError: Unable to locate CPLEX installation`
 
-Which version of CPLEX are you trying to install? Currently, CPLEX.jl only supports 1280 and 1290 given recent changes [the API](https://www.ibm.com/support/knowledgecenter/en/SSSA5P_12.9.0/ilog.odms.studio.help/CPLEX/ReleaseNotes/topics/releasenotes1290/removed.html). If your CPLEX version is < 1280, you can add the last supported version of CPLEX.jl via `julia> ] add CPLEX@0.4`. However, we recommend that you upgrade your version of CPLEX. If you want to support newer versions of CPLEX not listed above, [file an issue](https://github.com/JuliaOpt/CPLEX.jl/issues/new) with the version number you'd like to support. Some steps need to be taken (like checking for new or renamed parameters) before CPLEX.jl can support new versions.
+Which version of CPLEX are you trying to install? Currently, CPLEX.jl only
+supports 1280 and 1290 given recent changes to
+[the API](https://www.ibm.com/support/knowledgecenter/en/SSSA5P_12.9.0/ilog.odms.studio.help/CPLEX/ReleaseNotes/topics/releasenotes1290/removed.html).
 
-#### If you're on OS X or Linux
+If you want to support newer versions of CPLEX not listed above, [file an
+issue](https://github.com/JuliaOpt/CPLEX.jl/issues/new) with the version
+number you'd like to support. Some steps need to be taken (like checking for
+new or renamed parameters) before CPLEX.jl can support new versions.
 
-The most common problem is not setting `LD_LIBRARY_PATH` correctly. Open a terminal and check the output of
-```
-echo $LD_LIBRARY_PATH
-```
-is the path to the CPLEX installation. If it's not, did you follow step 2 above?
+## Use with JuMP
 
-Hint: on OS X the path should probably be something like
-`/Users/[username]/Applications/IBM/ILOG/CPLEX_Studio[version number]/cplex/bin/x86-64_osx/`
+You can use CPLEX with JuMP via the `CPLEX.Optimizer()` solver.
 
-#### If you're on Linux
-
-The most common problem is not setting `CPLEX_STUDIO_BINARIES` correctly. Open a Julia prompt and check that the output of
+Solver parameters can be set in the ``CPLEX.Optimizer()`` object using
+`MOI.RawParameter`. For example,
 ```julia
-julia> ENV["CPLEX_STUDIO_BINARIES"]
+MOI.set(model, MOI.RawParameter("CPX_PARAM_EPINT"), 1e-8)
 ```
-is the path to the CPLEX installation. If you get a `key "CPLEX_STUDIO_BINARIES" not found` error, make sure the environment variable is set correctly, or just set it from within the Julia prompt
-```julia
-julia> ENV["CPLEX_STUDIO_BINARIES"] = "path/to/cplex/installation"
-julia> Pkg.build("CPLEX")
-```
-Another alternative is to run
-```
-CPLEX_STUDIO_BINARIES="path/to/cplex/installation" julia -e 'Pkg.build("CPLEX")'
-```
-#### If you're on Windows
 
-The environment variable needs to be `CPLEX_STUDIO_BINARIESXXX` where `XXX` is the version of CPLEX.
-
-Parameters
-----------
-
-Solver parameters can be passed through the ``CplexSolver()`` object, e.g., ``CplexSolver(CPX_PARAM_EPINT=1e-8)``. Parameters match those of the CPLEX documentation. Additionally, the ``mipstart_effortlevel`` parameter can be used to tell CPLEX how much effort to put into turning warmstarts into feasible solutions, with possible values ``CPLEX.CPX_MIPSTART_AUTO``, ``CPLEX.CPX_MIPSTART_CHECKFEAS``, ``CPLEX.CPX_MIPSTART_SOLVEFIXED``, ``CPLEX.CPX_MIPSTART_SOLVEMIP``, ``CPLEX.CPX_MIPSTART_REPAIR``, and ``CPLEX.CPX_MIPSTART_NOCHECK``.
+Parameters match those of the C API in the [CPLEX documentation](https://www.ibm.com/support/knowledgecenter/SSSA5P_12.9.0/ilog.odms.cplex.help/CPLEX/Parameters/topics/introListAlpha.html).

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -44,9 +44,10 @@ function try_local_installation()
             push!(libnames, joinpath(cplex_path, name))
         end
         for env in [base_env, base_env * v]
-            !haskey(ENV, env) && continue
+            if !haskey(ENV, env)
+                continue
+            end
             for d in split(ENV[env], ';')
-                !occursin("cplex", d) && continue
                 push!(libnames, joinpath(d, name))
             end
         end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -16,10 +16,6 @@ function library_name(v)
     return "$(cpx_prefix)cplex$(v).$(Libdl.dlext)"
 end
 
-@static if Sys.isapple()
-    Libdl.dlopen("libstdc++", Libdl.RTLD_GLOBAL)
-end
-
 function try_local_installation()
     # Find the path to the CPLEX executable.
     cplex_path = try


### PR DESCRIPTION
Closes #97. I don't know why we enforced the path to contain `cplex`.

Closes #259. This appears to be a hold out from an early version of the install script https://github.com/JuliaOpt/CPLEX.jl/commit/83628ed5aa7584feeb3ebc4140b87be17ca264c8.
I tested on OSX, and we don't need this.