### PR TITLE
Skip install/test for GitHub Actions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CPLEX"
 uuid = "a076750e-1247-5638-91d2-ce28b192dca0"
 repo = "https://github.com/JuliaOpt/CPLEX.jl"
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -68,11 +68,10 @@ function try_local_installation()
 end
 
 function try_travis_installation()
-    url = get(ENV, "SECRET_CPLEX_URL")
+    url = ENV["SECRET_CPLEX_URL"]
     local_filename = joinpath(@__DIR__, "libcplex.so")
     download(url, local_filename)
     write_depsfile(local_filename)
-    return
 end
 
 if get(ENV, "TRAVIS", "false") == "true"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -68,10 +68,18 @@ function try_local_installation()
 end
 
 function try_travis_installation()
-    url = ENV["SECRET_CPLEX_URL"]
+    url = get(ENV, "SECRET_CPLEX_URL", nothing)
+    if url === nothing
+        # We must be running on a fork other than JuliaOpt/CPLEX.jl.
+        # As suggested by @fredrikekre https://github.com/JuliaRegistries/General/pull/5236#issuecomment-552646659
+        # silently skip the tests. This allows repos like the General registry
+        # to "think" that Travis is passing tests.
+        return
+    end
     local_filename = joinpath(@__DIR__, "libcplex.so")
     download(url, local_filename)
     write_depsfile(local_filename)
+    return
 end
 
 if get(ENV, "TRAVIS", "false") == "true"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -68,14 +68,7 @@ function try_local_installation()
 end
 
 function try_travis_installation()
-    url = get(ENV, "SECRET_CPLEX_URL", nothing)
-    if url === nothing
-        # We must be running on a fork other than JuliaOpt/CPLEX.jl.
-        # As suggested by @fredrikekre https://github.com/JuliaRegistries/General/pull/5236#issuecomment-552646659
-        # silently skip the tests. This allows repos like the General registry
-        # to "think" that Travis is passing tests.
-        return
-    end
+    url = get(ENV, "SECRET_CPLEX_URL")
     local_filename = joinpath(@__DIR__, "libcplex.so")
     download(url, local_filename)
     write_depsfile(local_filename)
@@ -84,6 +77,12 @@ end
 
 if get(ENV, "TRAVIS", "false") == "true"
     try_travis_installation()
+elseif get(ENV, "GITHUB_ACTIONS", "false") == "true"
+    # We're being run as part of a Github action. The most likely case is that
+    # this is the auto-merge action as part of the General registry.
+    # For now, we're going to silently skip the installation.
+    #
+    # TODO(odow): remove this once we distribute the community edition.
 else
     try_local_installation()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,11 @@
+if get(ENV, "TRAVIS", "false") == "true" && get(ENV, "SECRET_CPLEX_URL", nothing) === nothing
+    # If we're running on TRAVIS, but there isn't the secret URL,  then it means
+    # that we're being tested from an account other than JuliaOpt. To enable
+    # auto-merge on the General registry, silently exit tests indicating that
+    # we passed.
+    exit(0)
+end
+
 using Test
 import Pkg
 using MathProgBase

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,9 @@
-if get(ENV, "TRAVIS", "false") == "true" && get(ENV, "SECRET_CPLEX_URL", nothing) === nothing
-    # If we're running on TRAVIS, but there isn't the secret URL,  then it means
-    # that we're being tested from an account other than JuliaOpt. To enable
-    # auto-merge on the General registry, silently exit tests indicating that
-    # we passed.
+if get(ENV, "GITHUB_ACTIONS", "false") == "true"
+    # We're being run as part of a Github action. The most likely case is that
+    # this is the auto-merge action as part of the General registry.
+    # For now, we're going to silently skip the tests.
+    #
+    # TODO(odow): remove this once we distribute the community edition.
     exit(0)
 end
 


### PR DESCRIPTION
CPLEX's binary dependency is preventing us from meeting the auto-merge standards. This could be resolved by distributing the community edition.

However, in the meantime, [@fredrikekre suggested](https://github.com/JuliaRegistries/General/pull/5236#issuecomment-552646659) that we just skip the tests if we detect we're being called from GitHub Actions.