### PR TITLE
Specialization of MOI.delete for vector of variables

### DIFF
--- a/src/MOI/MOI_wrapper.jl
+++ b/src/MOI/MOI_wrapper.jl
@@ -489,7 +489,7 @@ end
 function intervalize(xs)
     starts, ends = empty(xs), empty(xs)
     for x in xs
-      if empty(starts) || x != last(ends) + 1
+      if isempty(starts) || x != last(ends) + 1
         push!(starts, x)
         push!(ends, x)
       else


### PR DESCRIPTION
Arised from a discussion with @odow and @mlubin.

MOI.delete already has a fallback method for a vector of variable parameters (which just calls the single variable delete over each variable of the vector). In Gurobi, the problem is that this fallback has O(n^2) performance the way the things are now; in CPLEX the problem is smaller but, if an user tries to delete one or more intervals of a large number of contiguously indexed variables, then the current code does not take advantage of the fact CPLEX is optimized to do this natively. The proposed change creates the smallest list of intervals and then call delete on them in reverse order (just to minimize the variable block shifts inside CPLEX, if they are done, but also because this simplifies the code that compute the correspondence between indexes).