### PR TITLE
Remove General Registry checks.

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -74,36 +74,8 @@ function try_travis_installation()
     write_depsfile(local_filename)
 end
 
-"""
-    is_general_registry()
-
-Detect if we are being called from AutoMerge CI on the Julia General registry.
-
-The Julia General registry attempts to install and test packages. Since it does't have a
-CPLEX license, this build will fail, preventing auto-merge. Therefore, we need to detect
-when we are being called and silently bail.
-
-Complicating matters is the very particular way in which we get called, because we don't get
-a typical installation. In particular, a very restricted set of environment variables is
-passed. See here for details:
-https://github.com/JuliaRegistries/RegistryCI.jl/blob/0d19525c7120176e5e0f11637dcca7b229b5f0c9/src/AutoMerge/guidelines.jl#L178-L196
-
-This check is fragile, and subject to breakage. But it seems highly unlikely that a user
-will have a set-up identical to this.
-"""
-function is_general_registry()
-    return all([
-        haskey(ENV, "PATH"),
-        haskey(ENV, "JULIA_DEPOT_PATH"),
-        get(ENV, "PYTHON", "false") == "",
-        get(ENV, "R_HOME", "false") == "*",
-    ])
-end
-
 if get(ENV, "TRAVIS", "false") == "true"
     try_travis_installation()
-elseif is_general_registry()
-    # TODO(odow): remove this once we distribute the community edition.
 else
     try_local_installation()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,34 +1,3 @@
-"""
-    is_general_registry()
-
-Detect if we are being called from AutoMerge CI on the Julia General registry.
-
-The Julia General registry attempts to install and test packages. Since it does't have a
-CPLEX license, this build will fail, preventing auto-merge. Therefore, we need to detect
-when we are being called and silently bail.
-
-Complicating matters is the very particular way in which we get called, because we don't get
-a typical installation. In particular, a very restricted set of environment variables is
-passed. See here for details:
-https://github.com/JuliaRegistries/RegistryCI.jl/blob/0d19525c7120176e5e0f11637dcca7b229b5f0c9/src/AutoMerge/guidelines.jl#L178-L196
-
-This check is fragile, and subject to breakage. But it seems highly unlikely that a user
-will have a set-up identical to this.
-"""
-function is_general_registry()
-    return all([
-        haskey(ENV, "PATH"),
-        haskey(ENV, "JULIA_DEPOT_PATH"),
-        get(ENV, "PYTHON", "false") == "",
-        get(ENV, "R_HOME", "false") == "*",
-    ])
-end
-
-if is_general_registry()
-    # TODO(odow): remove this once we distribute the community edition.
-    exit(0)
-end
-
 using Test
 import Pkg
 using MathProgBase


### PR DESCRIPTION
The issue is that it isn't sufficient to skip the build and test phases.
It is also necessary to skip the `import CPLEX` line, which I don't
know how to do without some ugly hacks. Therefore, just delete the
registry detection code. This will necessitate manual merges on the Julia
registry; oh well.

This will be fixed when we distribute the community edition.